### PR TITLE
Fix wrong data for fortress loans

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1356,7 +1356,7 @@
     "name": "Fortress Loans",
     "type": "Price Manipulation",
     "Lost": 3000000.0,
-    "lossType": "ETH",
+    "lossType": "USD",
     "Contract": "src/test/2022-05/FortressLoans_exp.sol"
   },
   {


### PR DESCRIPTION
3 million loss is incorrectly calcualted as 5.5 billion in lossed,fixed for proper data 