### PR TITLE
feat: add Discord-sourced incidents 2026-06-26

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,1166 @@
 [
   {
+    "date": "20260625",
+    "name": "LixirPermitDrain",
+    "type": "Broken Signature Verification",
+    "Lost": 2.6,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-06/LixirPermitDrain_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260625",
+    "name": "OceanBPoolSideStaking",
+    "type": "BPool single-sided join/exit math with SideStaking gulp accounting",
+    "Lost": 127860.0,
+    "lossType": "MOCEAN",
+    "Contract": "src/test/2026-06/OceanBPoolSideStaking_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260624",
+    "name": "DLMC",
+    "type": "Reserve-derived livePrice manipulation",
+    "Lost": 222560.22,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/DLMC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260623",
+    "name": "RoyalRoyalties",
+    "type": "Zero-amount ERC1155 batch transfer inflated Royal LDA tier balance",
+    "Lost": 261162.93,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260620",
+    "name": "OLPC",
+    "type": "OLPC pair reserve manipulation",
+    "Lost": 1115903.66,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/OLPC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260620",
+    "name": "JaredFromSubway",
+    "type": "MEV Exploit",
+    "Lost": 4424.0,
+    "lossType": "ETH",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260618",
+    "name": "JB",
+    "type": "JB helper repeated cycle drains JB/USDT pair",
+    "Lost": 49958.06,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/JB_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260617",
+    "name": "WHALE",
+    "type": "Transfer Accounting Reserve Desync",
+    "Lost": 3460.41,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/WHALE_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260617",
+    "name": "LBP",
+    "type": "LBP balanceOf reward accounting",
+    "Lost": 610.56,
+    "lossType": "BNB",
+    "Contract": "src/test/2026-06/LBP_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260617",
+    "name": "Aztec V1",
+    "type": "escapeHatch Proof-Forgery (permissionless RollupProcessor exit)",
+    "Lost": 2200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/AztecEscapeHatch_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260616",
+    "name": "DIP",
+    "type": "Fee-on-Transfer Reserve Manipulation",
+    "Lost": 111097.59,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-06/DIP_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260615",
+    "name": "Thetanuts",
+    "type": "Index vault component-share accounting flaw",
+    "Lost": 105471.5,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-06/Thetanuts_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260614",
+    "name": "Aztec Connect",
+    "type": "numRealTxs Proof/Settlement Mismatch (permissionless RollupProcessorV3)",
+    "Lost": 2190000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/AztecConnect_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260609",
+    "name": "TOPBPool",
+    "type": "Governance-controlled token mint and Balancer pool drain",
+    "Lost": 944.2,
+    "lossType": "WETH",
+    "Contract": "src/test/2026-06/TOPBPool_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260609",
+    "name": "NovaBox",
+    "type": "Constructor Dividend Checkpoint Bypass",
+    "Lost": 56.73,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-06/NovaBox_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260607",
+    "name": "AmbientCrocSwapDex",
+    "type": "Native surplus accounting flaw",
+    "Lost": 67.85,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-06/AmbientCrocSwapDex_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260606",
+    "name": "BOSS",
+    "type": "BOSS helper mint/burn and transfer-tax pool skew",
+    "Lost": 10207.54,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/BOSS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260605",
+    "name": "DTXT",
+    "type": "Liquidity Misclassification Fee Bypass",
+    "Lost": 35041.11,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/DTXT_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260605",
+    "name": "AISOTHPresale",
+    "type": "Fixed-price presale arbitrage",
+    "Lost": 30314.76,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-06/AISOTHPresale_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260604",
+    "name": "BYToken",
+    "type": "Permissionless triggerAutoBurn Reserve Manipulation",
+    "Lost": 87402.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/BYToken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260530",
+    "name": "AROS",
+    "type": "Signature Replay",
+    "Lost": 295000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/AROS_exp.sol",
+    "chain": "Unknown"
+  },
+  {
+    "date": "20260529",
+    "name": "YSDAO",
+    "type": "Price Manipulation and Tax Bypass",
+    "Lost": 19490.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-05/YSDAO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260528",
+    "name": "LegendaryMoneyMonNft",
+    "type": "ecrecover address(0) Signature Bypass",
+    "Lost": 85500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/LegendaryMoneyMonNft_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260528",
+    "name": "DxSale",
+    "type": "Ownership Override Attack",
+    "Lost": 7300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/DxSale_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260527",
+    "name": "Joe Agent",
+    "type": "Reentrancy in removeLiquidityViaContract",
+    "Lost": 45000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/JoeAgent_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260526",
+    "name": "SKP Token",
+    "type": "Owner Backdoor LP Burn + Price Manipulation",
+    "Lost": 212000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/SKP_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260525",
+    "name": "New Market Trading",
+    "type": "SquidRouterModule Missing Caller Check",
+    "Lost": 3980000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/NewMarketTrading_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260525",
+    "name": "WUSD.fi",
+    "type": "_englove Sybil Incentive Abuse",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/WUSD_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260525",
+    "name": "SquidRouterModule",
+    "type": "Missing caller check",
+    "Lost": 0.25,
+    "lossType": "WBTC",
+    "Contract": "src/test/2026-05/SquidRouterModule_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260522",
+    "name": "FractalProtocol",
+    "type": "Business Logic Flaw",
+    "Lost": 13700.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/FractalProtocol_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260521",
+    "name": "MureDistribution",
+    "type": "Signature Verification Bypass",
+    "Lost": 5.45,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-05/MureDistribution_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260520",
+    "name": "MAPProtocol",
+    "type": "Arbitrary Mint",
+    "Lost": 180000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/MAPProtocol_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260519",
+    "name": "ElevateFi",
+    "type": "Reserve Price Manipulation",
+    "Lost": 16000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/ElevateFi_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260518",
+    "name": "TesseraSwap",
+    "type": "Callback Repayment Price Spread",
+    "Lost": 20000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/TesseraSwap_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260517",
+    "name": "VerusBridge",
+    "type": "Insufficient Validation",
+    "Lost": 11580000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/VerusBridge_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260517",
+    "name": "SEAToken",
+    "type": "Business Logic Flaw",
+    "Lost": 110000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/SEAToken_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260515",
+    "name": "AdsharesBridge",
+    "type": "Insufficient Validation",
+    "Lost": 628000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/AdsharesBridge_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260512",
+    "name": "SQTokenStaking",
+    "type": "Access Control",
+    "Lost": 346100.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/SQTokenStaking_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260511",
+    "name": "INKFinance",
+    "type": "Business Logic Flaw",
+    "Lost": 140000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/INKFinance_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260511",
+    "name": "HumaFinance",
+    "type": "Credit Approval Bypass",
+    "Lost": 101000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/HumaCreditApprovalBypass_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260510",
+    "name": "Renegade",
+    "type": "Uninitialized Proxy",
+    "Lost": 209000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/Renegade_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260507",
+    "name": "TrustedVolumes",
+    "type": "Signature Replay",
+    "Lost": 5870000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/TrustedVolumes_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260505",
+    "name": "Ekubo",
+    "type": "Business Logic Flaw",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-05/Ekubo_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260501",
+    "name": "SharwaMarginTrading",
+    "type": "Hegic collateral spot price manipulation",
+    "Lost": 32850.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-05/SharwaMarginTrading_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260428",
+    "name": "RWAVault",
+    "type": "Missing ERC4626 allowance check",
+    "Lost": 398655.47,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-04/RWAVault_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260428",
+    "name": "JUDAO",
+    "type": "JUDAO sell-hook reserve drain",
+    "Lost": 205000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-04/JUDAO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260427",
+    "name": "Unverified_a152",
+    "type": "AllowanceTarget approval drain",
+    "Lost": 229000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-04/unverified_a152_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260425",
+    "name": "SingularityDynaVault",
+    "type": "Oracle Misconfiguration / Share Inflation",
+    "Lost": 413130.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-04/SingularityDynaVault_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260423",
+    "name": "GiddyVaultV3",
+    "type": "Incomplete Signature Coverage",
+    "Lost": 1300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-04/giddyvaultv3_compound_auth_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260421",
+    "name": "KipseliPropAMM",
+    "type": "Pricing / Decimals Mismatch",
+    "Lost": 0.93,
+    "lossType": "CBBTC",
+    "Contract": "src/test/2026-04/KipseliPropAMM_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260420",
+    "name": "JuiceboxREVLoans",
+    "type": "Fake terminal loan source validation bypass",
+    "Lost": 21.77,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-04/JuiceboxREVLoans_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260420",
+    "name": "ThetanutsVaultShareRounding",
+    "type": "Vault Share Rounding Manipulation",
+    "Lost": 0.15,
+    "lossType": "WBTC",
+    "Contract": "src/test/2026-04/ThetanutsVaultShareRounding_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260419",
+    "name": "AaveRebalancerCreditDelegation",
+    "type": "Arbitrary External Call / Credit Delegation Abuse",
+    "Lost": 6999.91,
+    "lossType": "WAVAX",
+    "Contract": "src/test/2026-04/AaveRebalancerCreditDelegation_exp.sol",
+    "chain": "Avalanche"
+  },
+  {
+    "date": "20260415",
+    "name": "XLootStaking",
+    "type": "Duplicate xLOOT Redemption",
+    "Lost": 6.21,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-04/XLootStaking_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260414",
+    "name": "MONA LisaVault",
+    "type": "reward-farming / BurnAddress accounting exploit!",
+    "Lost": 60950.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-04/MONA_LisaVault_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260414",
+    "name": "Saturn Protocol",
+    "type": "Vulnerability Disclosure",
+    "Lost": 0.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-04/SaturnProtocol_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260412",
+    "name": "SubQuerySettings",
+    "type": "Settings access control",
+    "Lost": 218070000.0,
+    "lossType": "SQT",
+    "Contract": "src/test/2026-04/SubQuerySettings_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260407",
+    "name": "SquidMulticallAllowanceDrain",
+    "type": "Arbitrary Call / Wrong Approval",
+    "Lost": 1.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-04/SquidMulticallAllowanceDrain_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260405",
+    "name": "PerpPair",
+    "type": "Virtual AMM Manipulation",
+    "Lost": 165000.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-04/PerpPair_exp.sol",
+    "chain": "Linea"
+  },
+  {
+    "date": "20260331",
+    "name": "WhalebitOracleManipulation",
+    "type": "Algebra spot-price oracle manipulation",
+    "Lost": 824000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-03/WhalebitOracleManipulation_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260328",
+    "name": "VTSwapHook",
+    "type": "Pricing Error in UniswapV4 Hook",
+    "Lost": 4507034.03,
+    "lossType": "VATH",
+    "Contract": "src/test/2026-03/VTSwapHook_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260327",
+    "name": "EST Token",
+    "type": "Incorrect Token Burn Mechanism",
+    "Lost": 150.2,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-03/EST_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260324",
+    "name": "XocolatlLiquidator",
+    "type": "Access Control / Input Validation",
+    "Lost": 3.25,
+    "lossType": "CBETH",
+    "Contract": "src/test/2026-03/XocolatlLiquidator_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260324",
+    "name": "Univ3CollateralToken",
+    "type": "Logic Error",
+    "Lost": 57000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-03/Univ3CollateralToken_exp.sol",
+    "chain": "Optimism"
+  },
+  {
+    "date": "20260323",
+    "name": "BCE",
+    "type": "Deflationary Token Logic Error",
+    "Lost": 800000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-03/bce_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260319",
+    "name": "ATMBlindBox",
+    "type": "Weak Randomness / Predictable RNG",
+    "Lost": 99000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-03/ATMBlindBox_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260319",
+    "name": "Revamp",
+    "type": "Reward Accounting Drain",
+    "Lost": 2.99,
+    "lossType": "BNB",
+    "Contract": "src/test/2026-03/Revamp_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260316",
+    "name": "unverified",
+    "type": "CheckoutPool Old BOC Missing Access Control",
+    "Lost": 85730.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-03/unverified_1304_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20260315",
+    "name": "Venus THE",
+    "type": "BorrowBehalf + Donation Attack",
+    "Lost": 913858.2633605214,
+    "lossType": "CAKE",
+    "Contract": "src/test/2026-03/Venus_THE_exp.sol",
+    "chain": "Unknown"
+  },
+  {
+    "date": "20260315",
+    "name": "StakeOnMe",
+    "type": "Owner-privileged JAKE burn reserve drain",
+    "Lost": 0.28,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-03/unverified_237d_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260310",
+    "name": "AlkemiEarn",
+    "type": "Business Logic",
+    "Lost": 43.45,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-03/AlkemiEarn_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260302",
+    "name": "Curve LlamaLend",
+    "type": "Share price manipulation",
+    "Lost": 240000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-03/Curve_LlamaLend_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260222",
+    "name": "LAXO Token",
+    "type": "Incorrect Burn Logic",
+    "Lost": 137000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-02/LAXO_Token_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260216",
+    "name": "XDKRecycle",
+    "type": "XDK recycle reserve manipulation",
+    "Lost": 6.84,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-02/XDKRecycle_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260215",
+    "name": "Moonwell",
+    "type": "Faulty Oracle",
+    "Lost": 1780000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-02/Moonwell_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260120",
+    "name": "SynapLogic",
+    "type": "Business Logic Flaw",
+    "Lost": 27.6,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-01/SynapLogic_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260112",
+    "name": "MTToken",
+    "type": "Incorrect Fee Logic",
+    "Lost": 37000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-01/MTToken_exp.sol",
+    "chain": "Unknown"
+  },
+  {
+    "date": "20260110",
+    "name": "FutureSwap",
+    "type": "Unit Mismatch",
+    "Lost": 433000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-01/futureswap_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20260109",
+    "name": "Truebit",
+    "type": "OverFlow",
+    "Lost": 8540.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-01/Truebit_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260101",
+    "name": "PRXVT",
+    "type": "Bussiness Logic Flaw",
+    "Lost": 32.8,
+    "lossType": "ETH",
+    "Contract": "src/test/2026-01/PRXVT_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20251201",
+    "name": "yETH",
+    "type": "Unsafe Math",
+    "Lost": 9000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-12/yETH_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20251110",
+    "name": "DRLVaultV3",
+    "type": "Price Manipulation",
+    "Lost": 100000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-11/DRLVaultV3_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20251104",
+    "name": "Moonwell",
+    "type": "Faulty Oracle",
+    "Lost": 1000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-11/Moonwell_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20251103",
+    "name": "BalancerV2",
+    "type": "Precision Loss",
+    "Lost": 120000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-11/BalancerV2_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20251020",
+    "name": "SharwaFinance",
+    "type": "Post Insolvency Check",
+    "Lost": 146000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-10/SharwaFinance_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20251007",
+    "name": "TokenHolder",
+    "type": "Access Control",
+    "Lost": 20.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2025-10/TokenHolder_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20251004",
+    "name": "Abracadabra",
+    "type": "Logic Flaw",
+    "Lost": 1800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-10/Abracadabra_exp.sol",
+    "chain": "Unknown"
+  },
+  {
+    "date": "20250913",
+    "name": "Kame",
+    "type": "Arbitary External Call",
+    "Lost": 18167.8,
+    "lossType": "USD",
+    "Contract": "src/test/2025-09/Kame_exp.sol",
+    "chain": "Sei"
+  },
+  {
+    "date": "20250831",
+    "name": "Hexotic",
+    "type": "Incorrect Input Validation",
+    "Lost": 500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/Hexotic_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250830",
+    "name": "EverValueCoin",
+    "type": "Arbitrage",
+    "Lost": 100000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/EverValueCoin",
+    "chain": "Unknown"
+  },
+  {
+    "date": "20250827",
+    "name": "0xf340",
+    "type": "Access Control",
+    "Lost": 4000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/0xf340_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250823",
+    "name": "ABCCApp",
+    "type": "Lack of Access Control",
+    "Lost": 10100.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/ABCCApp_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250820",
+    "name": "MulticallWithXera",
+    "type": "Access Control",
+    "Lost": 17000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/MulticallWithXera_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250820",
+    "name": "0x8d2e",
+    "type": "Access Control",
+    "Lost": 40000.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2025-08/0x8d2e_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20250816",
+    "name": "d3xai",
+    "type": "Price Manipulation",
+    "Lost": 190.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2025-08/d3xai_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250815",
+    "name": "PDZ",
+    "type": "Price Manipulation",
+    "Lost": 3.3,
+    "lossType": "BNB",
+    "Contract": "src/test/2025-08/PDZ_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250815",
+    "name": "SizeCredit",
+    "type": "Access Control",
+    "Lost": 19700.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/SizeCredit_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250813",
+    "name": "YuliAI",
+    "type": "Price Manipulation",
+    "Lost": 78000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2025-08/YuliAI_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250813",
+    "name": "coinbase",
+    "type": "Misconfiguration",
+    "Lost": 300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/coinbase_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250813",
+    "name": "Grizzifi",
+    "type": "Logic Flaw",
+    "Lost": 61000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/Grizzifi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250812",
+    "name": "Bebop",
+    "type": "Arbitrary user input",
+    "Lost": 21000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-08/Bebop_dex_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20250811",
+    "name": "WXC",
+    "type": "Incorrect token burn mechanism",
+    "Lost": 37.5,
+    "lossType": "WBNB",
+    "Contract": "src/test/2025-08/WXC_Token_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250728",
+    "name": "SuperRare",
+    "type": "Access Control",
+    "Lost": 730000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/SuperRare_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250726",
+    "name": "MulticallWithETH",
+    "type": "arbitrary-call",
+    "Lost": 10000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/MulticallWithETH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250724",
+    "name": "SWAPPStaking",
+    "type": "Incorrect Reward calculation",
+    "Lost": 32196.28,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/SWAPPStaking_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250720",
+    "name": "Stepp2p",
+    "type": "Logic Flaw",
+    "Lost": 43000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/Stepp2p_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250717",
+    "name": "WETC",
+    "type": "Incorrect Burn Logic",
+    "Lost": 101000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/WETC_Token_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250716",
+    "name": "VDS",
+    "type": "Logic Flaw",
+    "Lost": 13000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/VDS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250709",
+    "name": "GMX",
+    "type": "Share price manipulation",
+    "Lost": 41000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/gmx_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20250705",
+    "name": "Unverified",
+    "type": "Access Control",
+    "Lost": 285700.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/unverified_54cd_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250705",
+    "name": "RANT",
+    "type": "Logic Flaw",
+    "Lost": 204000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-07/RANTToken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250702",
+    "name": "FPC",
+    "type": "Logic Flaw",
+    "Lost": 4700000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2025-07/FPC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250629",
+    "name": "Stead",
+    "type": "Access Control",
+    "Lost": 14500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/Stead_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20250626",
+    "name": "ResupplyFi",
+    "type": "Share price manipulation",
+    "Lost": 9600000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/ResupplyFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250625",
+    "name": "Unverified_b5cb",
+    "type": "Access Control",
+    "Lost": 2000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/unverified_b5cb_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250623",
+    "name": "GradientMakerPool",
+    "type": "Price Oracle Manipulation",
+    "Lost": 5000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/GradientMakerPool_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250620",
+    "name": "Gangsterfinance",
+    "type": "Incorrect dividends",
+    "Lost": 16500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/Gangsterfinance_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250619",
+    "name": "BankrollStack",
+    "type": "Incorrect dividends calculation",
+    "Lost": 5000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/BankrollStack_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250619",
+    "name": "BankrollNetwork",
+    "type": "Incorrect dividends calculation",
+    "Lost": 24.5,
+    "lossType": "WBNB",
+    "Contract": "src/test/2025-06/BankrollNetwork_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250617",
+    "name": "MetaPool",
+    "type": "Access Control",
+    "Lost": 25000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/MetaPool_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250612",
+    "name": "AAVEBoost",
+    "type": "Logic Flaw",
+    "Lost": 14800.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/AAVEBoost_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250610",
+    "name": "Unverified_8490",
+    "type": "Access Control",
+    "Lost": 48300.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-06/unverified_8490_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250528",
+    "name": "Corkprotocol",
+    "type": "Access Control",
+    "Lost": 12000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/Corkprotocol_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250527",
+    "name": "UsualMoney",
+    "type": "Arbitrage",
+    "Lost": 43000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/UsualMoney_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20250526",
+    "name": "YDT",
+    "type": "Logic Flaw",
+    "Lost": 41000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/YDTtoken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250524",
+    "name": "RICE",
+    "type": "Lack of Access Control",
+    "Lost": 88100.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/RICE_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20250520",
+    "name": "IRYSAI",
+    "type": "rug pull",
+    "Lost": 69600.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/IRYSAI_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250518",
+    "name": "KRC",
+    "type": "deflationary token",
+    "Lost": 7000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/KRCToken_pair_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20250514",
+    "name": "Unwarp",
+    "type": "lack-of-access-control",
+    "Lost": 9000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/Unwarp_exp.sol",
+    "chain": "Base"
+  },
+  {
     "date": "20250511",
     "name": "MBUToken",
     "type": "Price Manipulation not confirmed",
@@ -7,6 +1168,15 @@
     "lossType": "BUSD",
     "Contract": "src/test/2025-05/MBUToken_exp.sol",
     "chain": "BSC"
+  },
+  {
+    "date": "20250509",
+    "name": "Nalakuvara_LotteryTicket50",
+    "type": "Price Manipulation",
+    "Lost": 105500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2025-05/Nalakuvara_LotteryTicket50_exp.sol",
+    "chain": "Base"
   },
   {
     "date": "20250426",
@@ -97,15 +1267,6 @@
     "lossType": "USD",
     "Contract": "src/test/2025-03/OneInchFusionV1SettlementHack.sol_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20241210",
-    "name": "CloberDEX",
-    "type": "Reentrancy Attack",
-    "Lost": 501000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-12/CloberDEX_exp.sol",
-    "chain": "Base"
   },
   {
     "date": "20250223",
@@ -243,1606 +1404,1390 @@
     "chain": "Ethereum"
   },
   {
-    "date": "20211221",
-    "name": "Visor Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 8199999.999999999,
-    "lossType": "USD",
-    "Contract": "src/test/2021-12/Visor_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20211218",
-    "name": "Grim Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 30000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-12/Grim_exp.sol",
-    "chain": "Fantom"
-  },
-  {
-    "date": "20211214",
-    "name": "Nerve Bridge",
-    "type": "Swap Metapool Attack",
-    "Lost": 900.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2021-12/NerveBridge_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20211130",
-    "name": "MonoX Finance",
-    "type": "Price Manipulation",
-    "Lost": 31000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-11/Mono_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20211123",
-    "name": "Ploutoz",
-    "type": "Flash Loan Attack",
-    "Lost": 365000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-11/Ploutoz_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20211027",
-    "name": "CreamFinance",
-    "type": "Price Manipulation",
-    "Lost": 130000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-10/Cream_2_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20211015",
-    "name": "Indexed Finance",
-    "type": "Price Manipulation",
-    "Lost": 16000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-10/IndexedFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210916",
-    "name": "SushiSwap Miso",
-    "type": "Incorrect Validation",
-    "Lost": 3000000,
-    "lossType": "USD",
-    "Contract": "src/test/2021-09/Sushimiso_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210915",
-    "name": "Nimbus Platform",
+    "date": "20241223",
+    "name": "Moonhacker",
     "type": "Logic Flaw",
-    "Lost": 1.45,
-    "lossType": "ETH",
-    "Contract": "src/test/2021-09/Nimbus_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210915",
-    "name": "NowSwap Platform",
-    "type": "Logic Flaw",
-    "Lost": 1000000.0,
+    "Lost": 318900.0,
     "lossType": "USD",
-    "Contract": "src/test/2021-09/NowSwap_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210912",
-    "name": "ZABU Finance",
-    "type": "Deflationary Token Incompatible",
-    "Lost": 3200000,
-    "lossType": "USD",
-    "Contract": "src/test/2021-09/ZABU_exp.sol",
-    "chain": "Avalanche"
-  },
-  {
-    "date": "20210903",
-    "name": "DAO Maker",
-    "type": "Access Control",
-    "Lost": 4000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-09/DaoMaker_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210830",
-    "name": "Cream Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 18000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-08/Cream_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210817",
-    "name": "XSURGE",
-    "type": "Reentrancy Attack",
-    "Lost": 5000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-08/XSURGE_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210811",
-    "name": "Poly Network",
-    "type": "Bridge Attack",
-    "Lost": 611000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-08/PolyNetwork_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210804",
-    "name": "WaultFinace",
-    "type": "Price Manipulation",
-    "Lost": 390.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2021-08/WaultFinance_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210728",
-    "name": "Levyathan Finance",
-    "type": "Private Key Compromised",
-    "Lost": 1500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-07/Levyathan_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210710",
-    "name": "Chainswap_",
-    "type": "Logic Flaw",
-    "Lost": 4400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-07/Chainswap_exp2.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210702",
-    "name": "Chainswap",
-    "type": "Logic Flaw",
-    "Lost": 800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-07/Chainswap_exp1.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210628",
-    "name": "SafeDollar",
-    "type": "Deflationary Token Incompatible",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-06/SafeDollar_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20210625",
-    "name": "xWin Finance",
-    "type": "Logic Flaw",
-    "Lost": 300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-06/xWin_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210622",
-    "name": "Eleven Finance",
-    "type": "Logic Flaw",
-    "Lost": 4500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-06/Eleven_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210607",
-    "name": "88mph NFT",
-    "type": "Access Control",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2021-06/88mph_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210603",
-    "name": "PancakeHunny",
-    "type": "Logic Flaw",
-    "Lost": 43,
-    "lossType": "ETH",
-    "Contract": "src/test/2021-06/PancakeHunny_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210527",
-    "name": "JulSwap",
-    "type": "Flash Loan Attack",
-    "Lost": 1500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/JulSwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210527",
-    "name": "BurgerSwap",
-    "type": "Reentrancy Attack",
-    "Lost": 7000000,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/BurgerSwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210519",
-    "name": "PancakeBunny",
-    "type": "Price Manipulation",
-    "Lost": 45000000,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/PancakeBunny_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210516",
-    "name": "bEarn",
-    "type": "Logic Flaw",
-    "Lost": 11000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/bEarn_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210509",
-    "name": "RariCapital",
-    "type": "Reentrancy Attack",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/RariCapital_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210508",
-    "name": "Value Defi",
-    "type": "Reentrancy Attack",
-    "Lost": 10000000,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/ValueDefi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210502",
-    "name": "Spartan",
-    "type": "Logic Flaw",
-    "Lost": 30500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-05/Spartan_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20210428",
-    "name": "Uranium",
-    "type": "Logic Flaw",
-    "Lost": 50000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-04/Uranium_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20200912",
-    "name": "bzx",
-    "type": "Logic Flaw",
-    "Lost": 8100000,
-    "lossType": "USD",
-    "Contract": "src/test/2020-09/bzx_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20180424",
-    "name": "SmartMesh",
-    "type": "Overflow",
-    "Lost": 140000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2018-04/SmartMesh_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210308",
-    "name": "DODO",
-    "type": "Flash Loan Attack",
-    "Lost": 700000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-03/dodo_flashloan_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210305",
-    "name": "Paid Network",
-    "type": "Private Key Compromised",
-    "Lost": 3000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-03/PAID_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210204",
-    "name": "Yearn YDai",
-    "type": "Slippage",
-    "Lost": 11000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2021-02/Yearn_ydai_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20210125",
-    "name": "Sushi Badger Digg",
-    "type": "Sandwich Attack",
-    "Lost": 81.68,
-    "lossType": "ETH",
-    "Contract": "src/test/2021-01/Sushi_Badger_Digg_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20201229",
-    "name": "Cover Protocol",
-    "type": "Logic Flaw",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2020-12/Cover_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20201121",
-    "name": "Pickle Finance",
-    "type": "Incorrect Validation",
-    "Lost": 20000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2020-11/Pickle_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20201026",
-    "name": "Harvest Finance",
-    "type": "Flash Loan Attack",
-    "Lost": 33800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2020-10/HarvestFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20200804",
-    "name": "Opyn Protocol",
-    "type": "Logic Flaw",
-    "Lost": 370000,
-    "lossType": "USD",
-    "Contract": "src/test/2020-08/Opyn_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20200628",
-    "name": "Balancer Protocol",
-    "type": "Token Incompatible",
-    "Lost": 500000,
-    "lossType": "USD",
-    "Contract": "src/test/2020-06/Balancer_20200628_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20200618",
-    "name": "Bancor Protocol",
-    "type": "Access Control",
-    "Lost": 545000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2020-06/Bancor_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20200419",
-    "name": "LendfMe",
-    "type": "Reentrancy Attack",
-    "Lost": 25000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2020-04/LendfMe_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20200418",
-    "name": "UniSwapV1",
-    "type": "Reentrancy Attack",
-    "Lost": 220000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2020-04/uniswap-erc777.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20181007",
-    "name": "SpankChain",
-    "type": "Reentrancy Attack",
-    "Lost": 155.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2018-10/SpankChain_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20180422",
-    "name": "Beauty Chain",
-    "type": "Overflow",
-    "Lost": 900000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2018-04/BEC_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20171106",
-    "name": "Parity",
-    "type": "Access Control",
-    "Lost": 514000.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2017-11/Parity_kill_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221230",
-    "name": "DFS",
-    "type": "Incorrect Validation",
-    "Lost": 1450.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/DFS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221229",
-    "name": "JAY",
-    "type": "Reentrancy Attack",
-    "Lost": 15.32,
-    "lossType": "ETH",
-    "Contract": "src/test/2022-12/JAY_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221225",
-    "name": "Rubic",
-    "type": "Arbitrary Call",
-    "Lost": 1500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/Rubic_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221223",
-    "name": "Defrost",
-    "type": "Reentrancy Attack",
-    "Lost": 170000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/Defrost_exp.sol",
-    "chain": "Avalanche"
-  },
-  {
-    "date": "20221214",
-    "name": "Nmbplatform",
-    "type": "Price Manipulation",
-    "Lost": 76000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/Nmbplatform_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221214",
-    "name": "FPR",
-    "type": "Access Control",
-    "Lost": 29000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/FPR_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221213",
-    "name": "ElasticSwap",
-    "type": "Logic Flaw",
-    "Lost": 845000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/ElasticSwap_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221212",
-    "name": "BGLD (Deflationary token)",
-    "type": "Price Manipulation",
-    "Lost": 18000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/BGLD_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221211",
-    "name": "Lodestar",
-    "type": "Price Manipulation",
-    "Lost": 4000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/Lodestar_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20221211",
-    "name": "MEVbot_0x28d9",
-    "type": "Logic Flaw",
-    "Lost": 2000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/MEVbot_0x28d9_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221210",
-    "name": "MU&MUG",
-    "type": "Price Manipulation",
-    "Lost": 57000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/MUMUG_exp.sol",
-    "chain": "Avalanche"
-  },
-  {
-    "date": "20221210",
-    "name": "TIFIToken",
-    "type": "Price Manipulation",
-    "Lost": 87.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2022-12/TIFI_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221209",
-    "name": "NOVAToken",
-    "type": "Social Engineering",
-    "Lost": 330.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-12/NovaExchange_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221207",
-    "name": "AES (Deflationary token)",
-    "type": "Price Manipulation",
-    "Lost": 60000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/AES_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221205",
-    "name": "RFB",
-    "type": "Weak RNG",
-    "Lost": 12.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-12/RFB_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221205",
-    "name": "BBOX",
-    "type": "Price Manipulation",
-    "Lost": 12000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/BBOX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221202",
-    "name": "OverNight",
-    "type": "Flash Loan Attack",
-    "Lost": 170000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/Overnight_exp.sol",
-    "chain": "Avalanche"
-  },
-  {
-    "date": "20221201",
-    "name": "APC",
-    "type": "Price Manipulation",
-    "Lost": 6000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-12/APC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221129",
-    "name": "MBC & ZZSH",
-    "type": "Access Control",
-    "Lost": 5600.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/MBC_ZZSH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221129",
-    "name": "SEAMAN",
-    "type": "Logic Flaw",
-    "Lost": 7000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/SEAMAN_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221123",
-    "name": "NUM",
-    "type": "Token Incompatible",
-    "Lost": 13000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/NUM_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221122",
-    "name": "AUR",
-    "type": "Access Control",
-    "Lost": 13000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/AUR_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221121",
-    "name": "sDAO",
-    "type": "Logic Flaw",
-    "Lost": 13000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/SDAO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221119",
-    "name": "AnnexFinance",
-    "type": "Flash Loan Attack",
-    "Lost": 3000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/Annex_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221118",
-    "name": "Polynomial",
-    "type": "Logic Flaw",
-    "Lost": 1400.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/Polynomial_exp.sol",
+    "Contract": "src/test/2024-12/Moonhacker_exp.sol",
     "chain": "Optimism"
   },
   {
-    "date": "20221117",
-    "name": "UEarnPool",
-    "type": "Flash Loan Attack",
-    "Lost": 24000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/UEarnPool_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221116",
-    "name": "SheepFarm",
-    "type": "Logic Flaw",
-    "Lost": 1.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-11/SheepFarm_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221110",
-    "name": "DFXFinance",
+    "date": "20241210",
+    "name": "CloberDEX",
     "type": "Reentrancy Attack",
-    "Lost": 4000000.0,
+    "Lost": 501000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-11/DFX_exp.sol",
-    "chain": "Ethereum"
+    "Contract": "src/test/2024-12/CloberDEX_exp.sol",
+    "chain": "Base"
   },
   {
-    "date": "20221109",
-    "name": "BrahTOPG",
-    "type": "Incorrect Validation",
-    "Lost": 89000.0,
+    "date": "20241203",
+    "name": "Pledge",
+    "type": "Access Control",
+    "Lost": 15000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-11/BrahTOPG_exp.sol",
-    "chain": "Ethereum"
+    "Contract": "src/test/2024-12/Pledge_exp.sol",
+    "chain": "BSC"
   },
   {
-    "date": "20221108",
-    "name": "MEV_0ad8",
-    "type": "Arbitrary Call",
-    "Lost": 282000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/MEV_0ad8_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221108",
-    "name": "Kashi",
-    "type": "Logic Flaw",
-    "Lost": 110000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-11/Kashi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221107",
-    "name": "MooCAKECTX",
+    "date": "20241119",
+    "name": "PolterFinance",
     "type": "Flash Loan Attack",
-    "Lost": 140000.0,
+    "Lost": 7000000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-11/MooCAKECTX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221105",
-    "name": "BDEX",
-    "type": "Logic Flaw",
-    "Lost": 16.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2022-11/BDEX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221027",
-    "name": "VTF Token",
-    "type": "Logic Flaw",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/VTF_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221027",
-    "name": "Team Finance",
-    "type": "Incorrect Validation",
-    "Lost": 15800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/TeamFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221026",
-    "name": "N00d Token",
-    "type": "Reentrancy Attack",
-    "Lost": 29000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/N00d_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221025",
-    "name": "ULME",
-    "type": "Access Control",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/ULME_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221024",
-    "name": "Market",
-    "type": "Reentrancy Attack",
-    "Lost": 220000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/Market_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20221024",
-    "name": "MulticallWithoutCheck",
-    "type": "Arbitrary Call",
-    "Lost": 600.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/MulticallWithoutCheck_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20221021",
-    "name": "OlympusDAO",
-    "type": "Incorrect Validation",
-    "Lost": 292000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/OlympusDao_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221020",
-    "name": "HEALTH",
-    "type": "Logic Flaw",
-    "Lost": 16.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-10/HEALTH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221020",
-    "name": "BEGO",
-    "type": "Signature Verification",
-    "Lost": 12.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-10/BEGO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221018",
-    "name": "HPAY",
-    "type": "Access Control",
-    "Lost": 115.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-10/HPAY_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221018",
-    "name": "PLTD",
-    "type": "Logic Flaw",
-    "Lost": 24000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/PLTD_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221017",
-    "name": "Uerii Token",
-    "type": "Access Control",
-    "Lost": 2400.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/Uerii_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221014",
-    "name": "INUKO",
-    "type": "Price Manipulation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/INUKO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221014",
-    "name": "EFLeverVault",
-    "type": "Flash Loan Attack",
-    "Lost": 750.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2022-10/EFLeverVault_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221014",
-    "name": "MEVBOTa47b",
-    "type": "Front-running Attack",
-    "Lost": 241000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/MEVa47b_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221012",
-    "name": "ATK",
-    "type": "Flash Loan Attack",
-    "Lost": 127000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/ATK_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221011",
-    "name": "Rabby Wallet SwapRouter",
-    "type": "Arbitrary Call",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/RabbyWallet_SwapRouter_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221011",
-    "name": "Templedao",
-    "type": "Access Control",
-    "Lost": 2300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/Templedao_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221010",
-    "name": "Carrot",
-    "type": "Access Control",
-    "Lost": 31318.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/Carrot_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221009",
-    "name": "Xave Finance",
-    "type": "Access Control",
-    "Lost": 700.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/XaveFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20221006",
-    "name": "RES-Token",
-    "type": "Price Manipulation",
-    "Lost": 290000,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/RES_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221002",
-    "name": "Transit Swap",
-    "type": "Incorrect Validation",
-    "Lost": 21000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/TransitSwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221001",
-    "name": "BabySwap",
-    "type": "Access Control",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/BabySwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221001",
-    "name": "RL Token",
-    "type": "Logic Flaw",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-10/RL_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20221001",
-    "name": "Thunder Brawl",
-    "type": "Reentrancy Attack",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/THB_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220928",
-    "name": "BXH",
-    "type": "Flash Loan Attack",
-    "Lost": 40305.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/BXH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220928",
-    "name": "MEVBOT_0xbaDc0dE",
-    "type": "Sandwich Attack",
-    "Lost": 94304.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/MEVbadc0de_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220923",
-    "name": "RADT-DAO",
-    "type": "Price Manipulation",
-    "Lost": 94304.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/RADT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220913",
-    "name": "MevBot private tx",
-    "type": "Access Control",
-    "Lost": 140000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/BNB48MEVBot_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220909",
-    "name": "DPC",
-    "type": "Logic Flaw",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/DPC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220908",
-    "name": "YYDS",
-    "type": "Price Manipulation",
-    "Lost": 742286.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/Yyds_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220908",
-    "name": "Ragnarok Online Invasion",
-    "type": "Access Control",
-    "Lost": 44000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/ROI_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220908",
-    "name": "NewFreeDAO",
-    "type": "Flash Loan Attack",
-    "Lost": 125000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/NewFreeDAO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220906",
-    "name": "NXUSD",
-    "type": "Flash Loan Attack",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/NXUSD_exp.sol",
-    "chain": "Avalanche"
-  },
-  {
-    "date": "20220905",
-    "name": "ZoomproFinance",
-    "type": "Price Manipulation",
-    "Lost": 61160.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/ZoomproFinance_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220902",
-    "name": "ShadowFi",
-    "type": "Access Control",
-    "Lost": 1078.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-09/Shadowfi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220902",
-    "name": "Bad Guys by RPF",
-    "type": "Incorrect Validation",
-    "Lost": 400.0,
-    "lossType": "RPF",
-    "Contract": "src/test/2022-09/BadGuysbyRPF_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220828",
-    "name": "DDC",
-    "type": "Access Control",
-    "Lost": 100000,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/DDC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220824",
-    "name": "LuckyTiger NFT",
-    "type": "Weak RNG",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/LuckyTiger_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220816",
-    "name": "Circle_",
-    "type": "Price Manipulation",
-    "Lost": 151600.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/Circle_exp2.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220813",
-    "name": "Circle",
-    "type": "Price Manipulation",
-    "Lost": 50500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/Circle_exp1.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220810",
-    "name": "XSTABLE Protocol",
-    "type": "Logic Flaw",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/XST_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220809",
-    "name": "ANCH",
-    "type": "Incorrect Validation",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/ANCH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220807",
-    "name": "EGD Finance",
-    "type": "Price Manipulation",
-    "Lost": 36044.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/EGD_Finance_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220804",
-    "name": "EtnProduct",
-    "type": "Logic Flaw",
-    "Lost": 3074.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/EtnProduct_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220803",
-    "name": "Qixi",
-    "type": "Overflow",
-    "Lost": 6.08,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-08/Qixi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220802",
-    "name": "Nomad Bridge",
-    "type": "Incorrect Validation",
-    "Lost": 152000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/NomadBridge_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220801",
-    "name": "Reaper Farm",
-    "type": "Access Control",
-    "Lost": 1700000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-08/ReaperFarm_exp.sol",
+    "Contract": "src/test/2024-11/PolterFinance_exploit.sol",
     "chain": "Fantom"
   },
   {
-    "date": "20220725",
-    "name": "LPC",
-    "type": "Incorrect Validation",
-    "Lost": 45000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-07/LPC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220723",
-    "name": "Audius",
-    "type": "Storage Collision",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-07/Audius_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220713",
-    "name": "SpaceGodzilla",
+    "date": "20241114",
+    "name": "vETH",
     "type": "Price Manipulation",
-    "Lost": 26000.0,
+    "Lost": 447000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-07/SpaceGodzilla_exp.sol",
-    "chain": "BSC"
+    "Contract": "src/test/2024-11/vETH_exp.sol",
+    "chain": "Ethereum"
   },
   {
-    "date": "20220710",
-    "name": "Omni NFT",
+    "date": "20241111",
+    "name": "DeltaPrime",
     "type": "Reentrancy Attack",
-    "Lost": 1400000.0,
+    "Lost": 4750000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-07/Omni_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220706",
-    "name": "FlippazOne NFT",
-    "type": "Access Control",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-07/FlippazOne_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220701",
-    "name": "Quixotic",
-    "type": "Incorrect Validation",
-    "Lost": 100000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-07/Quixotic_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220626",
-    "name": "XCarnival",
-    "type": "Flash Loan Attack",
-    "Lost": 3870000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-06/XCarnival_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220624",
-    "name": "Harmony's Horizon Bridge",
-    "type": "Private Key Compromised",
-    "Lost": 100000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-06/Harmony_multisig_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220618",
-    "name": "SNOOD",
-    "type": "Incorrect Validation",
-    "Lost": 104.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2022-06/Snood_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220616",
-    "name": "InverseFinance",
-    "type": "Flash Loan Attack",
-    "Lost": 1260000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-06/InverseFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220608",
-    "name": "GYMNetwork_",
-    "type": "Access Control",
-    "Lost": 2000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-06/Gym_2_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220608",
-    "name": "Optimism-Wintermute",
-    "type": "Bridge Attack",
-    "Lost": 20000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-06/Optimism_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220606",
-    "name": "Discover",
-    "type": "Flash Loan Attack",
-    "Lost": 49.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-06/Discover_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220529",
-    "name": "NOVO Protocol",
-    "type": "Flash Loan Attack",
-    "Lost": 279.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-05/Novo_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220524",
-    "name": "HackDao",
-    "type": "Logic Flaw",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-05/HackDao_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220517",
-    "name": "ApeCoin (APE)",
-    "type": "Flash Loan Attack",
-    "Lost": 1100000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-05/Bayc_apecoin_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220508",
-    "name": "Fortress Loans",
-    "type": "Price Manipulation",
-    "Lost": 3000000.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2022-05/FortressLoans_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220430",
-    "name": "Saddle Finance",
-    "type": "Swap Metapool Attack",
-    "Lost": 10000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/Saddle_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220430",
-    "name": "Rari Capital/Fei Protocol",
-    "type": "Reentrancy Attack",
-    "Lost": 80000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/Rari_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220428",
-    "name": "DEUS DAO",
-    "type": "Flash Loan Attack",
-    "Lost": 13000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/deus_exp.sol",
-    "chain": "Fantom"
-  },
-  {
-    "date": "20220424",
-    "name": "Wiener DOGE",
-    "type": "Flash Loan Attack",
-    "Lost": 78.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-04/Wdoge_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220423",
-    "name": "Akutar NFT",
-    "type": "Denial Of Service",
-    "Lost": 34000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/AkutarNFT_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220421",
-    "name": "Zeed Finance",
-    "type": "Logic Flaw",
-    "Lost": 1000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/Zeed_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220416",
-    "name": "BeanstalkFarms",
-    "type": "Flash Loan Attack",
-    "Lost": 182000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/Beanstalk_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220415",
-    "name": "Rikkei Finance",
-    "type": "Access Control",
-    "Lost": 1100000.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2022-04/Rikkei_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220412",
-    "name": "ElephantMoney",
-    "type": "Flash Loan Attack",
-    "Lost": 11200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/Elephant_Money_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220411",
-    "name": "Creat Future",
-    "type": "Overflow",
-    "Lost": 1900000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-04/cftoken_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220409",
-    "name": "GYMNetwork",
-    "type": "Flash Loan Attack",
-    "Lost": 1327,
-    "lossType": "WBNB",
-    "Contract": "src/test/2022-04/Gym_1_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220329",
-    "name": "Ronin Network",
-    "type": "Bridge Attack",
-    "Lost": 624000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Ronin_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220329",
-    "name": "Redacted Cartel",
-    "type": "Logic Flaw",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/RedactedCartel_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220327",
-    "name": "Revest Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 11200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Revest_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220326",
-    "name": "Auctus",
-    "type": "Arbitrary Call",
-    "Lost": 726000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Auctus_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220322",
-    "name": "CompoundTUSDSweepTokenBypass",
-    "type": "Incorrect Validation",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/CompoundTusd_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220321",
-    "name": "OneRing Finance",
-    "type": "Flash Loan Attack",
-    "Lost": 1450000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/OneRing_exp.sol",
-    "chain": "Fantom"
-  },
-  {
-    "date": "20220320",
-    "name": "Li.Fi",
-    "type": "Bridge Attack",
-    "Lost": 570000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/LiFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220320",
-    "name": "Umbrella Network",
-    "type": "Overflow",
-    "Lost": 700000,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Umbrella_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220313",
-    "name": "Hundred Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 1700000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/HundredFinance_exp.sol",
-    "chain": "Gnosis"
-  },
-  {
-    "date": "20220315",
-    "name": "Agave Finance",
-    "type": "Reentrancy Attack",
-    "Lost": 1500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Agave_exp.sol",
-    "chain": "Gnosis"
-  },
-  {
-    "date": "20220313",
-    "name": "Paraluni",
-    "type": "Reentrancy Attack",
-    "Lost": 1700000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Paraluni_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20220309",
-    "name": "Fantasm Finance",
-    "type": "Logic Flaw",
-    "Lost": 2600000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Fantasm_exp.sol",
-    "chain": "Fantom"
-  },
-  {
-    "date": "20220305",
-    "name": "Bacon Protocol",
-    "type": "Reentrancy Attack",
-    "Lost": 1000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/Bacon_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20220303",
-    "name": "TreasureDAO",
-    "type": "Incorrect Validation",
-    "Lost": 470000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-03/TreasureDAO_exp.sol",
+    "Contract": "src/test/2024-11/DeltaPrime_exp.sol",
     "chain": "Arbitrum"
   },
   {
-    "date": "20220214",
-    "name": "BuildFinance",
-    "type": "Governance Attack",
-    "Lost": 470000.0,
+    "date": "20241026",
+    "name": "CompoundFork",
+    "type": "Flash Loan Attack",
+    "Lost": 1000000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-02/BuildF_exp.sol",
+    "Contract": "src/test/2024-10/CompoundFork_exploit.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20241022",
+    "name": "Erc20transfer",
+    "type": "Access Control",
+    "Lost": 14773.35,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/Erc20transfer_exp.sol",
     "chain": "Ethereum"
   },
   {
-    "date": "20220208",
-    "name": "Sandbox LAND",
-    "type": "Access Control",
+    "date": "20241022",
+    "name": "Vista",
+    "type": "Logic Flaw",
+    "Lost": 28000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/VISTA_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20241013",
+    "name": "MorphoBlue",
+    "type": "Price Manipulation",
+    "Lost": 230000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/MorphoBlue_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20241011",
+    "name": "P719Token",
+    "type": "Price Manipulation",
+    "Lost": 312000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/P719Token_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20241006",
+    "name": "SASHAToken",
+    "type": "Price Manipulation",
+    "Lost": 600000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/SASHAToken_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20241006",
+    "name": "HYDT",
+    "type": "Price Manipulation",
     "Lost": null,
     "lossType": "USD",
-    "Contract": "src/test/2022-02/Sandbox_exp.sol",
-    "chain": "Ethereum"
+    "Contract": "src/test/2024-10/HYDT_exp.sol",
+    "chain": "BSC"
   },
   {
-    "date": "20220206",
-    "name": "Meter",
-    "type": "Bridge Attack",
-    "Lost": 4300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2022-02/meter_exp.sol",
-    "chain": "Moonriver"
-  },
-  {
-    "date": "20220204",
-    "name": "TecraSpace",
+    "date": "20241005",
+    "name": "AIZPTToken",
     "type": "Logic Flaw",
-    "Lost": 63000.0,
+    "Lost": 20000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-02/TecraSpace_exp.sol",
+    "Contract": "src/test/2024-10/AIZPTToken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20241002",
+    "name": "LavaLending_",
+    "type": "Price Manipulation",
+    "Lost": 130000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/LavaLending_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20241001",
+    "name": "FireToken",
+    "type": "Price Manipulation",
+    "Lost": 20000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-10/FireToken_exp.sol",
     "chain": "Ethereum"
   },
   {
-    "date": "20220128",
-    "name": "Qubit Finance",
-    "type": "Bridge Attack",
-    "Lost": 80000000.0,
+    "date": "20240926",
+    "name": "OnyxDAO",
+    "type": "Logic Flaw",
+    "Lost": 3800000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-01/Qubit_exp.sol",
+    "Contract": "src/test/2024-09/OnyxDAO_exp.sol",
     "chain": "Ethereum"
   },
   {
-    "date": "20220118",
-    "name": "Multichain (Anyswap)",
-    "type": "Incorrect Validation",
+    "date": "20240926",
+    "name": "Bedrock_DeFi",
+    "type": "Logic Flaw",
+    "Lost": 2000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-09/Bedrock_DeFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240923",
+    "name": "Bankroll_Network",
+    "type": "Logic Flaw",
+    "Lost": 404.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2024-09/Bankroll_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240913",
+    "name": "OTSeaStaking",
+    "type": "Logic Flaw",
+    "Lost": 26000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-09/OTSeaStaking_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240910",
+    "name": "Caterpillar_Coin_CUT",
+    "type": "Price Manipulation",
     "Lost": 1400000.0,
     "lossType": "USD",
-    "Contract": "src/test/2022-01/Anyswap_exp.sol",
+    "Contract": "src/test/2024-09/Caterpillar_Coin_CUT_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240903",
+    "name": "Penpiexyz_io",
+    "type": "Reentrancy Attack",
+    "Lost": 11113.6,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-09/Penpiexyzio_exp.sol",
     "chain": "Ethereum"
+  },
+  {
+    "date": "20240828",
+    "name": "AAVE",
+    "type": "Arbitrary Call",
+    "Lost": 52000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/AAVE_Repay_Adapter.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240816",
+    "name": "Zenterest",
+    "type": "Price Manipulation",
+    "Lost": 21000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/Zenterest_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240816",
+    "name": "OMPx Contract",
+    "type": "Flash Loan Attack",
+    "Lost": 4.37,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-08/OMPxContract_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240814",
+    "name": "NoName",
+    "type": "Arbitrary Call",
+    "Lost": 5000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/YodlRouter_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240813",
+    "name": "VOW",
+    "type": "Sandwich Attack",
+    "Lost": 1000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/VOW_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240812",
+    "name": "iVest",
+    "type": "Logic Flaw",
+    "Lost": 338.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2024-08/IvestDao_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240806",
+    "name": "Novax",
+    "type": "Price Manipulation",
+    "Lost": 25000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/NovaXM2E_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240801",
+    "name": "Convergence",
+    "type": "Logic Flaw",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-08/Convergence_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240724",
+    "name": "Spectra_finance",
+    "type": "Incorrect Validation",
+    "Lost": 73000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/Spectra_finance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240723",
+    "name": "MEVbot_0xdd7c",
+    "type": "Logic Flaw",
+    "Lost": 18000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/MEVbot_0xdd7c_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240716",
+    "name": "Lifiprotocol",
+    "type": "Incorrect Validation",
+    "Lost": 10000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/Lifiprotocol_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240714",
+    "name": "Minterest",
+    "type": "Reentrancy Attack",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/Minterest_exp.sol",
+    "chain": "Mantle"
+  },
+  {
+    "date": "20240712",
+    "name": "DoughFina",
+    "type": "Incorrect Validation",
+    "Lost": 1800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/DoughFina_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240711",
+    "name": "SBT",
+    "type": "Logic Flaw",
+    "Lost": 56000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/SBT_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240711",
+    "name": "GAX",
+    "type": "Access Control",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/GAX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240708",
+    "name": "LW2",
+    "type": "Overflow",
+    "Lost": 7000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/LW_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240705",
+    "name": "DeFiPlaza",
+    "type": "Logic Flaw",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-07/DeFiPlaza_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240703",
+    "name": "UnverifiedContr_0x452E25",
+    "type": "Access Control",
+    "Lost": 27.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-07/UnverifiedContr_0x452E25_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240702",
+    "name": "MRP",
+    "type": "Reentrancy Attack",
+    "Lost": 17.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-07/MRP_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240628",
+    "name": "Will",
+    "type": "Logic Flaw",
+    "Lost": 52000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/Will_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240627",
+    "name": "APEMAGA",
+    "type": "Logic Flaw",
+    "Lost": 9.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-06/APEMAGA_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240618",
+    "name": "INcufi",
+    "type": "Logic Flaw",
+    "Lost": 59000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/Incufi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240617",
+    "name": "Dyson_money",
+    "type": "Logic Flaw",
+    "Lost": 52.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-06/Dyson_money_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240616",
+    "name": "WIFCOIN_ETH",
+    "type": "Logic Flaw",
+    "Lost": 13189920.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/WIFCOIN_ETH_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240616",
+    "name": "Crb2",
+    "type": "Logic Flaw",
+    "Lost": 15000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/Crb2_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240611",
+    "name": "JokInTheBox",
+    "type": "Logic Flaw",
+    "Lost": 9.2,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-06/JokInTheBox_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240610",
+    "name": "UwULend",
+    "type": "Price Manipulation",
+    "Lost": 19300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/UwuLend_First_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240610",
+    "name": "Bazaar",
+    "type": "Access Control",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/Bazaar_exp.sol",
+    "chain": "Blast"
+  },
+  {
+    "date": "20240608",
+    "name": "YYStoken",
+    "type": "Logic Flaw",
+    "Lost": 28000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/YYS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240606",
+    "name": "SteamSwap",
+    "type": "Logic Flaw",
+    "Lost": 91000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/SteamSwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240606",
+    "name": "MineSTM",
+    "type": "Logic Flaw",
+    "Lost": 13800.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/MineSTM_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240604",
+    "name": "NCD",
+    "type": "Logic Flaw",
+    "Lost": 6400.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/NCD_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240601",
+    "name": "VeloCore",
+    "type": "Access Control",
+    "Lost": 6880000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-06/Velocore_exp.sol",
+    "chain": "Linea"
+  },
+  {
+    "date": "20240531",
+    "name": "Liquiditytokens",
+    "type": "Logic Flaw",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/Liquiditytokens_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240531",
+    "name": "MixedSwapRouter",
+    "type": "Arbitrary Call",
+    "Lost": 10700000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/MixedSwapRouter_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240529",
+    "name": "SCROLL",
+    "type": "Overflow",
+    "Lost": 76.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-05/SCROLL_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240529",
+    "name": "MetaDragon",
+    "type": "Access Control",
+    "Lost": 180000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/MetaDragon_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240528",
+    "name": "Tradeonorion",
+    "type": "Logic Flaw",
+    "Lost": 645000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/Tradeonorion_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240528",
+    "name": "EXcommunity",
+    "type": "Logic Flaw",
+    "Lost": 33.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-05/EXcommunity_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240527",
+    "name": "RedKeysCoin",
+    "type": "Weak RNG",
+    "Lost": 12000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/RedKeysCoin_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240526",
+    "name": "NORMIE",
+    "type": "Logic Flaw",
+    "Lost": 490000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/NORMIE_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20240522",
+    "name": "Burner",
+    "type": "Sandwich Attack",
+    "Lost": 1.7,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-05/Burner_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240516",
+    "name": "TCH",
+    "type": "Signature Verification",
+    "Lost": 18000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/TCH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240514",
+    "name": "Sonne Finance",
+    "type": "Precision Loss",
+    "Lost": 20000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/Sonne_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240514",
+    "name": "PredyFinance",
+    "type": "Reentrancy Attack",
+    "Lost": 464000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/PredyFinance_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240512",
+    "name": "TGC",
+    "type": "Logic Flaw",
+    "Lost": 32000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/TGC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240510",
+    "name": "GFOX",
+    "type": "Access Control",
+    "Lost": 330000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/GFOX_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240510",
+    "name": "TSURU",
+    "type": "Access Control",
+    "Lost": 140000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/TSURU_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20240508",
+    "name": "GPU",
+    "type": "Logic Flaw",
+    "Lost": 32000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/GPU_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240507",
+    "name": "SATURN",
+    "type": "Price Manipulation",
+    "Lost": 15.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-05/SATURN_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240506",
+    "name": "OSN",
+    "type": "Logic Flaw",
+    "Lost": 109000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-05/OSN_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240430",
+    "name": "Yield",
+    "type": "Incorrect Validation",
+    "Lost": 181000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/Yield_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240430",
+    "name": "PikeFinance",
+    "type": "Logic Flaw",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/PikeFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240427",
+    "name": "BNBX",
+    "type": "Precision Loss",
+    "Lost": 75.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-04/BNBX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240425",
+    "name": "NGFS",
+    "type": "Access Control",
+    "Lost": 190000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/NGFS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240424",
+    "name": "XBridge",
+    "type": "Access Control",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/XBridge_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240424",
+    "name": "YIEDL",
+    "type": "Incorrect Validation",
+    "Lost": 150000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/YIEDL_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240422",
+    "name": "Z123",
+    "type": "Price Manipulation",
+    "Lost": 136000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/Z123_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240420",
+    "name": "Rico",
+    "type": "Arbitrary Call",
+    "Lost": 36000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/Rico_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240419",
+    "name": "HedgeyFinance",
+    "type": "Logic Flaw",
+    "Lost": 48000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/HedgeyFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240417",
+    "name": "UnverifiedContr_0x00C409",
+    "type": "Logic Flaw",
+    "Lost": 18.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-04/UnverifiedContr_0x00C409_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240416",
+    "name": "SATX",
+    "type": "Access Control",
+    "Lost": 50.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-04/SATX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240416",
+    "name": "MARS",
+    "type": "Logic Flaw",
+    "Lost": 100000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/MARS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240415",
+    "name": "GFA",
+    "type": "Logic Flaw",
+    "Lost": 14000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/GFA_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240415",
+    "name": "ChaingeFinance",
+    "type": "Arbitrary Call",
+    "Lost": 560000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/ChaingeFinance_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240414",
+    "name": "Hackathon",
+    "type": "Logic Flaw",
+    "Lost": 20000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/Hackathon_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240412",
+    "name": "FIL314",
+    "type": "Arbitrary Call",
+    "Lost": 14.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-04/FIL314_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240412",
+    "name": "SumerMoney",
+    "type": "Reentrancy Attack",
+    "Lost": 350000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/SumerMoney_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20240412",
+    "name": "GROKD",
+    "type": "Access Control",
+    "Lost": 150.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-04/GROKD_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240410",
+    "name": "BigBangSwap",
+    "type": "Precision Loss",
+    "Lost": 5000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/BigBangSwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240409",
+    "name": "UPS",
+    "type": "Logic Flaw",
+    "Lost": 28000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/UPS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240408",
+    "name": "SQUID",
+    "type": "Sandwich Attack",
+    "Lost": 87000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/SQUID_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240404",
+    "name": "wsm",
+    "type": "Price Manipulation",
+    "Lost": 18000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/WSM_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240402",
+    "name": "HoppyFrogERC",
+    "type": "Logic Flaw",
+    "Lost": 0.3,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-04/HoppyFrogERC_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240401",
+    "name": "ATM",
+    "type": "Slippage",
+    "Lost": 182000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/ATM_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240401",
+    "name": "OpenLeverage2",
+    "type": "Logic Flaw",
+    "Lost": 234000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-04/OpenLeverage2_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240329",
+    "name": "ETHFIN",
+    "type": "Access Control",
+    "Lost": 1240.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-03/ETHFIN_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240329",
+    "name": "PrismaFi",
+    "type": "Incorrect Validation",
+    "Lost": 11000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/Prisma_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240328",
+    "name": "LavaLending",
+    "type": "Logic Flaw",
+    "Lost": 340000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/LavaLending_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240325",
+    "name": "ZongZi",
+    "type": "Price Manipulation",
+    "Lost": 223000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/ZongZi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240324",
+    "name": "ARK",
+    "type": "Logic Flaw",
+    "Lost": 348.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-03/ARK_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240323",
+    "name": "CGT",
+    "type": "Access Control",
+    "Lost": 2000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/CGT_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240321",
+    "name": "SSS",
+    "type": "Logic Flaw",
+    "Lost": 4800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/SSS_exp.sol",
+    "chain": "Blast"
+  },
+  {
+    "date": "20240320",
+    "name": "Paraswap",
+    "type": "Access Control",
+    "Lost": 24000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/Paraswap_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240314",
+    "name": "MO",
+    "type": "Logic Flaw",
+    "Lost": 413000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/MO_exp.sol",
+    "chain": "Optimism"
+  },
+  {
+    "date": "20240313",
+    "name": "IT",
+    "type": "Logic Flaw",
+    "Lost": 13000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/IT_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240312",
+    "name": "BBT",
+    "type": "Logic Flaw",
+    "Lost": 5.06,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-03/BBT_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240311",
+    "name": "Binemon",
+    "type": "Precision Loss",
+    "Lost": 413000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/Binemon_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240309",
+    "name": "Juice",
+    "type": "Logic Flaw",
+    "Lost": 54.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-03/Juice_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240309",
+    "name": "UnizenIO",
+    "type": "Logic Flaw",
+    "Lost": 2000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/UnizenIO_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240307",
+    "name": "GHT",
+    "type": "Logic Flaw",
+    "Lost": 57000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/GHT_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240306",
+    "name": "ALP",
+    "type": "Access Control",
+    "Lost": 10000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/ALP_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240306",
+    "name": "TGBS",
+    "type": "Logic Flaw",
+    "Lost": 150000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/TGBS_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240305",
+    "name": "Woofi",
+    "type": "Price Manipulation",
+    "Lost": 8000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-03/Woofi_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240228",
+    "name": "Seneca",
+    "type": "Arbitrary Call",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/Seneca_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240228",
+    "name": "SMOOFSStaking",
+    "type": "Reentrancy Attack",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/SMOOFSStaking_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20240223",
+    "name": "Zoomer",
+    "type": "Logic Flaw",
+    "Lost": 14.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-02/Zoomer_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240223",
+    "name": "CompoundUni",
+    "type": "Price Manipulation",
+    "Lost": 439537.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/CompoundUni_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240223",
+    "name": "BlueberryProtocol",
+    "type": "Logic Flaw",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/BlueberryProtocol_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240222",
+    "name": "SwarmMarkets",
+    "type": "Logic Flaw",
+    "Lost": 120000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/SwarmMarkets_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240221",
+    "name": "DeezNutz 404",
+    "type": "Logic Flaw",
+    "Lost": 170000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/DeezNutz404_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240221",
+    "name": "GAIN",
+    "type": "Deflationary Token Incompatible",
+    "Lost": 6.4,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-02/GAIN_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240220",
+    "name": "EGGX",
+    "type": "Reentrancy Attack",
+    "Lost": 2.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-02/EGGX_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240219",
+    "name": "RuggedArt",
+    "type": "Reentrancy Attack",
+    "Lost": 10000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/RuggedArt_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240216",
+    "name": "ParticleTrade",
+    "type": "Incorrect Validation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/ParticleTrade_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240215",
+    "name": "DualPools",
+    "type": "Logic Flaw",
+    "Lost": 42000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/DualPools_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240215",
+    "name": "Babyloogn",
+    "type": "Logic Flaw",
+    "Lost": 2.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2024-02/Babyloogn_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240215",
+    "name": "Miner",
+    "type": "Incorrect Validation",
+    "Lost": 150000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/Miner_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240213",
+    "name": "MINER",
+    "type": "Price Manipulation",
+    "Lost": 3.5,
+    "lossType": "WBNB",
+    "Contract": "src/test/2024-02/MINER_bsc_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240211",
+    "name": "Game",
+    "type": "Reentrancy Attack",
+    "Lost": 20.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-02/Game_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240210",
+    "name": "FILX DN404",
+    "type": "Access Control",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/DN404_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240208",
+    "name": "Pandora",
+    "type": "Overflow",
+    "Lost": 17000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/PANDORA_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240205",
+    "name": "BurnsDefi",
+    "type": "Price Manipulation",
+    "Lost": 67000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/BurnsDefi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240202",
+    "name": "ADC",
+    "type": "Access Control",
+    "Lost": 20.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2024-02/ADC_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240201",
+    "name": "AffineDeFi",
+    "type": "Incorrect Validation",
+    "Lost": 88000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-02/AffineDeFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240130",
+    "name": "XSIJ",
+    "type": "Logic Flaw",
+    "Lost": 51000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/XSIJ_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240130",
+    "name": "MIMSpell_",
+    "type": "Precision Loss",
+    "Lost": 65000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/MIMSpell2_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240129",
+    "name": "PeapodsFinance",
+    "type": "Reentrancy Attack",
+    "Lost": 1000.0,
+    "lossType": "DAI",
+    "Contract": "src/test/2024-01/PeapodsFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240128",
+    "name": "BarleyFinance",
+    "type": "Reentrancy Attack",
+    "Lost": 130000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/BarleyFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240127",
+    "name": "CitadelFinance",
+    "type": "Price Manipulation",
+    "Lost": 93000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/CitadelFinance_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240125",
+    "name": "NBLGAME",
+    "type": "Reentrancy Attack",
+    "Lost": 180000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/NBLGAME_exp.sol",
+    "chain": "Optimism"
+  },
+  {
+    "date": "20240122",
+    "name": "DAO_SoulMate",
+    "type": "Access Control",
+    "Lost": 319000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/DAO_SoulMate_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240117",
+    "name": "BmiZapper",
+    "type": "Incorrect Validation",
+    "Lost": 114000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/BmiZapper_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240115",
+    "name": "Shell_MEV_0xa898",
+    "type": "Access Control",
+    "Lost": 1000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/Shell_MEV_0xa898_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240112",
+    "name": "SocketGateway",
+    "type": "Incorrect Validation",
+    "Lost": 3300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/SocketGateway_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240112",
+    "name": "WiseLending",
+    "type": "Precision Loss",
+    "Lost": 464000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/WiseLending02_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240110",
+    "name": "Freedom",
+    "type": "Access Control",
+    "Lost": 74.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2024-01/Freedom_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240110",
+    "name": "LQDX",
+    "type": "Incorrect Validation",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/LQDX_alert_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20240104",
+    "name": "Gamma",
+    "type": "Price Manipulation",
+    "Lost": 6300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/Gamma_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240102",
+    "name": "MIC",
+    "type": "Logic Flaw",
+    "Lost": 500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/MIC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20240102",
+    "name": "RadiantCapital",
+    "type": "Logic Flaw",
+    "Lost": 4500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/RadiantCapital_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20240101",
+    "name": "OrbitChain",
+    "type": "Incorrect Validation",
+    "Lost": 81000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2024-01/OrbitChain_exp.sol",
+    "chain": "BSC"
   },
   {
     "date": "20231231",
@@ -3249,21 +4194,21 @@
     "chain": "BSC"
   },
   {
-    "date": "20230512",
-    "name": "LW",
-    "type": "Price Manipulation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2023-05/LW_exp.sol",
-    "chain": "BSC"
-  },
-  {
     "date": "20230513",
     "name": "SellToken02",
     "type": "Price Manipulation",
     "Lost": 197000.0,
     "lossType": "USD",
     "Contract": "src/test/2023-05/SellToken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20230512",
+    "name": "LW",
+    "type": "Price Manipulation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2023-05/LW_exp.sol",
     "chain": "BSC"
   },
   {
@@ -3771,2541 +4716,1605 @@
     "chain": "BSC"
   },
   {
-    "date": "20241223",
-    "name": "Moonhacker",
-    "type": "Logic Flaw",
-    "Lost": 318900.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-12/Moonhacker_exp.sol",
-    "chain": "Optimism"
-  },
-  {
-    "date": "20241203",
-    "name": "Pledge",
-    "type": "Access Control",
-    "Lost": 15000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-12/Pledge_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20241119",
-    "name": "PolterFinance",
-    "type": "Flash Loan Attack",
-    "Lost": 7000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-11/PolterFinance_exploit.sol",
-    "chain": "Fantom"
-  },
-  {
-    "date": "20241114",
-    "name": "vETH",
-    "type": "Price Manipulation",
-    "Lost": 447000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-11/vETH_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20241111",
-    "name": "DeltaPrime",
-    "type": "Reentrancy Attack",
-    "Lost": 4750000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-11/DeltaPrime_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20241026",
-    "name": "CompoundFork",
-    "type": "Flash Loan Attack",
-    "Lost": 1000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/CompoundFork_exploit.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20241022",
-    "name": "Erc20transfer",
-    "type": "Access Control",
-    "Lost": 14773.35,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/Erc20transfer_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20241022",
-    "name": "Vista",
-    "type": "Logic Flaw",
-    "Lost": 28000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/VISTA_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20241013",
-    "name": "MorphoBlue",
-    "type": "Price Manipulation",
-    "Lost": 230000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/MorphoBlue_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20241011",
-    "name": "P719Token",
-    "type": "Price Manipulation",
-    "Lost": 312000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/P719Token_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20241006",
-    "name": "SASHAToken",
-    "type": "Price Manipulation",
-    "Lost": 600000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/SASHAToken_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20241006",
-    "name": "HYDT",
-    "type": "Price Manipulation",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/HYDT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20241005",
-    "name": "AIZPTToken",
-    "type": "Logic Flaw",
-    "Lost": 20000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/AIZPTToken_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20241001",
-    "name": "FireToken",
-    "type": "Price Manipulation",
-    "Lost": 20000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/FireToken_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20241002",
-    "name": "LavaLending_",
-    "type": "Price Manipulation",
-    "Lost": 130000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-10/LavaLending_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240926",
-    "name": "OnyxDAO",
-    "type": "Logic Flaw",
-    "Lost": 3800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-09/OnyxDAO_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240926",
-    "name": "Bedrock_DeFi",
-    "type": "Logic Flaw",
-    "Lost": 2000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-09/Bedrock_DeFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240923",
-    "name": "Bankroll_Network",
-    "type": "Logic Flaw",
-    "Lost": 404.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2024-09/Bankroll_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240913",
-    "name": "OTSeaStaking",
-    "type": "Logic Flaw",
-    "Lost": 26000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-09/OTSeaStaking_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240910",
-    "name": "Caterpillar_Coin_CUT",
-    "type": "Price Manipulation",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-09/Caterpillar_Coin_CUT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240903",
-    "name": "Penpiexyz_io",
-    "type": "Reentrancy Attack",
-    "Lost": 11113.6,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-09/Penpiexyzio_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240828",
-    "name": "AAVE",
-    "type": "Arbitrary Call",
-    "Lost": 52000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/AAVE_Repay_Adapter.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240816",
-    "name": "Zenterest",
-    "type": "Price Manipulation",
-    "Lost": 21000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/Zenterest_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240816",
-    "name": "OMPx Contract",
-    "type": "Flash Loan Attack",
-    "Lost": 4.37,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-08/OMPxContract_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240814",
-    "name": "NoName",
-    "type": "Arbitrary Call",
-    "Lost": 5000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/YodlRouter_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240813",
-    "name": "VOW",
-    "type": "Sandwich Attack",
-    "Lost": 1000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/VOW_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240812",
-    "name": "iVest",
-    "type": "Logic Flaw",
-    "Lost": 338.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2024-08/IvestDao_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240806",
-    "name": "Novax",
-    "type": "Price Manipulation",
-    "Lost": 25000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/NovaXM2E_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240801",
-    "name": "Convergence",
-    "type": "Logic Flaw",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-08/Convergence_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240724",
-    "name": "Spectra_finance",
+    "date": "20221230",
+    "name": "DFS",
     "type": "Incorrect Validation",
-    "Lost": 73000.0,
+    "Lost": 1450.0,
     "lossType": "USD",
-    "Contract": "src/test/2024-07/Spectra_finance_exp.sol",
-    "chain": "Ethereum"
+    "Contract": "src/test/2022-12/DFS_exp.sol",
+    "chain": "BSC"
   },
   {
-    "date": "20240723",
-    "name": "MEVbot_0xdd7c",
-    "type": "Logic Flaw",
-    "Lost": 18000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/MEVbot_0xdd7c_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240716",
-    "name": "Lifiprotocol",
-    "type": "Incorrect Validation",
-    "Lost": 10000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/Lifiprotocol_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240714",
-    "name": "Minterest",
+    "date": "20221229",
+    "name": "JAY",
     "type": "Reentrancy Attack",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/Minterest_exp.sol",
-    "chain": "Mantle"
-  },
-  {
-    "date": "20240712",
-    "name": "DoughFina",
-    "type": "Incorrect Validation",
-    "Lost": 1800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/DoughFina_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240711",
-    "name": "SBT",
-    "type": "Logic Flaw",
-    "Lost": 56000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/SBT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240711",
-    "name": "GAX",
-    "type": "Access Control",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/GAX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240708",
-    "name": "LW2",
-    "type": "Overflow",
-    "Lost": 7000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/LW_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240705",
-    "name": "DeFiPlaza",
-    "type": "Logic Flaw",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-07/DeFiPlaza_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240703",
-    "name": "UnverifiedContr_0x452E25",
-    "type": "Access Control",
-    "Lost": 27.0,
+    "Lost": 15.32,
     "lossType": "ETH",
-    "Contract": "src/test/2024-07/UnverifiedContr_0x452E25_exp.sol",
+    "Contract": "src/test/2022-12/JAY_exp.sol",
     "chain": "Ethereum"
   },
   {
-    "date": "20240702",
-    "name": "MRP",
+    "date": "20221225",
+    "name": "Rubic",
+    "type": "Arbitrary Call",
+    "Lost": 1500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/Rubic_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221223",
+    "name": "Defrost",
     "type": "Reentrancy Attack",
-    "Lost": 17.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-07/MRP_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240628",
-    "name": "Will",
-    "type": "Logic Flaw",
-    "Lost": 52000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/Will_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240627",
-    "name": "APEMAGA",
-    "type": "Logic Flaw",
-    "Lost": 9.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-06/APEMAGA_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240618",
-    "name": "INcufi",
-    "type": "Logic Flaw",
-    "Lost": 59000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/Incufi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240617",
-    "name": "Dyson_money",
-    "type": "Logic Flaw",
-    "Lost": 52.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-06/Dyson_money_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240616",
-    "name": "WIFCOIN_ETH",
-    "type": "Logic Flaw",
-    "Lost": 13189920.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/WIFCOIN_ETH_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240616",
-    "name": "Crb2",
-    "type": "Logic Flaw",
-    "Lost": 15000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/Crb2_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240611",
-    "name": "JokInTheBox",
-    "type": "Logic Flaw",
-    "Lost": 9.2,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-06/JokInTheBox_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240610",
-    "name": "UwULend",
-    "type": "Price Manipulation",
-    "Lost": 19300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/UwuLend_First_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240610",
-    "name": "Bazaar",
-    "type": "Access Control",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/Bazaar_exp.sol",
-    "chain": "Blast"
-  },
-  {
-    "date": "20240608",
-    "name": "YYStoken",
-    "type": "Logic Flaw",
-    "Lost": 28000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/YYS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240606",
-    "name": "SteamSwap",
-    "type": "Logic Flaw",
-    "Lost": 91000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/SteamSwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240606",
-    "name": "MineSTM",
-    "type": "Logic Flaw",
-    "Lost": 13800.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/MineSTM_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240604",
-    "name": "NCD",
-    "type": "Logic Flaw",
-    "Lost": 6400.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/NCD_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240601",
-    "name": "VeloCore",
-    "type": "Access Control",
-    "Lost": 6880000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-06/Velocore_exp.sol",
-    "chain": "Linea"
-  },
-  {
-    "date": "20240531",
-    "name": "Liquiditytokens",
-    "type": "Logic Flaw",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/Liquiditytokens_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240531",
-    "name": "MixedSwapRouter",
-    "type": "Arbitrary Call",
-    "Lost": 10700000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/MixedSwapRouter_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240529",
-    "name": "SCROLL",
-    "type": "Overflow",
-    "Lost": 76.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-05/SCROLL_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240529",
-    "name": "MetaDragon",
-    "type": "Access Control",
-    "Lost": 180000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/MetaDragon_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240528",
-    "name": "Tradeonorion",
-    "type": "Logic Flaw",
-    "Lost": 645000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/Tradeonorion_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240528",
-    "name": "EXcommunity",
-    "type": "Logic Flaw",
-    "Lost": 33.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-05/EXcommunity_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240527",
-    "name": "RedKeysCoin",
-    "type": "Weak RNG",
-    "Lost": 12000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/RedKeysCoin_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240526",
-    "name": "NORMIE",
-    "type": "Logic Flaw",
-    "Lost": 490000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/NORMIE_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20240522",
-    "name": "Burner",
-    "type": "Sandwich Attack",
-    "Lost": 1.7,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-05/Burner_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240516",
-    "name": "TCH",
-    "type": "Signature Verification",
-    "Lost": 18000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/TCH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240514",
-    "name": "Sonne Finance",
-    "type": "Precision Loss",
-    "Lost": 20000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/Sonne_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240514",
-    "name": "PredyFinance",
-    "type": "Reentrancy Attack",
-    "Lost": 464000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/PredyFinance_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240512",
-    "name": "TGC",
-    "type": "Logic Flaw",
-    "Lost": 32000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/TGC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240510",
-    "name": "GFOX",
-    "type": "Access Control",
-    "Lost": 330000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/GFOX_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240510",
-    "name": "TSURU",
-    "type": "Access Control",
-    "Lost": 140000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/TSURU_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20240508",
-    "name": "GPU",
-    "type": "Logic Flaw",
-    "Lost": 32000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/GPU_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240507",
-    "name": "SATURN",
-    "type": "Price Manipulation",
-    "Lost": 15.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-05/SATURN_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240506",
-    "name": "OSN",
-    "type": "Logic Flaw",
-    "Lost": 109000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-05/OSN_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240430",
-    "name": "Yield",
-    "type": "Incorrect Validation",
-    "Lost": 181000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/Yield_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240430",
-    "name": "PikeFinance",
-    "type": "Logic Flaw",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/PikeFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240427",
-    "name": "BNBX",
-    "type": "Precision Loss",
-    "Lost": 75.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-04/BNBX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240425",
-    "name": "NGFS",
-    "type": "Access Control",
-    "Lost": 190000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/NGFS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240424",
-    "name": "XBridge",
-    "type": "Access Control",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/XBridge_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240424",
-    "name": "YIEDL",
-    "type": "Incorrect Validation",
-    "Lost": 150000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/YIEDL_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240422",
-    "name": "Z123",
-    "type": "Price Manipulation",
-    "Lost": 136000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/Z123_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240420",
-    "name": "Rico",
-    "type": "Arbitrary Call",
-    "Lost": 36000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/Rico_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240419",
-    "name": "HedgeyFinance",
-    "type": "Logic Flaw",
-    "Lost": 48000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/HedgeyFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240417",
-    "name": "UnverifiedContr_0x00C409",
-    "type": "Logic Flaw",
-    "Lost": 18.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-04/UnverifiedContr_0x00C409_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240416",
-    "name": "SATX",
-    "type": "Access Control",
-    "Lost": 50.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-04/SATX_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240416",
-    "name": "MARS",
-    "type": "Logic Flaw",
-    "Lost": 100000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/MARS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240415",
-    "name": "GFA",
-    "type": "Logic Flaw",
-    "Lost": 14000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/GFA_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240415",
-    "name": "ChaingeFinance",
-    "type": "Arbitrary Call",
-    "Lost": 560000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/ChaingeFinance_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240414",
-    "name": "Hackathon",
-    "type": "Logic Flaw",
-    "Lost": 20000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/Hackathon_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240412",
-    "name": "FIL314",
-    "type": "Arbitrary Call",
-    "Lost": 14.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-04/FIL314_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240412",
-    "name": "SumerMoney",
-    "type": "Reentrancy Attack",
-    "Lost": 350000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/SumerMoney_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20240412",
-    "name": "GROKD",
-    "type": "Access Control",
-    "Lost": 150.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-04/GROKD_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240410",
-    "name": "BigBangSwap",
-    "type": "Precision Loss",
-    "Lost": 5000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/BigBangSwap_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240409",
-    "name": "UPS",
-    "type": "Logic Flaw",
-    "Lost": 28000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/UPS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240408",
-    "name": "SQUID",
-    "type": "Sandwich Attack",
-    "Lost": 87000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/SQUID_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240404",
-    "name": "wsm",
-    "type": "Price Manipulation",
-    "Lost": 18000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/WSM_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240402",
-    "name": "HoppyFrogERC",
-    "type": "Logic Flaw",
-    "Lost": 0.3,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-04/HoppyFrogERC_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240401",
-    "name": "ATM",
-    "type": "Slippage",
-    "Lost": 182000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/ATM_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240401",
-    "name": "OpenLeverage2",
-    "type": "Logic Flaw",
-    "Lost": 234000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-04/OpenLeverage2_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240329",
-    "name": "ETHFIN",
-    "type": "Access Control",
-    "Lost": 1240.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-03/ETHFIN_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240329",
-    "name": "PrismaFi",
-    "type": "Incorrect Validation",
-    "Lost": 11000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/Prisma_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240328",
-    "name": "LavaLending",
-    "type": "Logic Flaw",
-    "Lost": 340000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/LavaLending_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240325",
-    "name": "ZongZi",
-    "type": "Price Manipulation",
-    "Lost": 223000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/ZongZi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240323",
-    "name": "CGT",
-    "type": "Access Control",
-    "Lost": 2000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/CGT_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240321",
-    "name": "SSS",
-    "type": "Logic Flaw",
-    "Lost": 4800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/SSS_exp.sol",
-    "chain": "Blast"
-  },
-  {
-    "date": "20240324",
-    "name": "ARK",
-    "type": "Logic Flaw",
-    "Lost": 348.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-03/ARK_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240320",
-    "name": "Paraswap",
-    "type": "Access Control",
-    "Lost": 24000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/Paraswap_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240314",
-    "name": "MO",
-    "type": "Logic Flaw",
-    "Lost": 413000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/MO_exp.sol",
-    "chain": "Optimism"
-  },
-  {
-    "date": "20240313",
-    "name": "IT",
-    "type": "Logic Flaw",
-    "Lost": 13000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/IT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240312",
-    "name": "BBT",
-    "type": "Logic Flaw",
-    "Lost": 5.06,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-03/BBT_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240311",
-    "name": "Binemon",
-    "type": "Precision Loss",
-    "Lost": 413000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/Binemon_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240309",
-    "name": "Juice",
-    "type": "Logic Flaw",
-    "Lost": 54.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-03/Juice_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240309",
-    "name": "UnizenIO",
-    "type": "Logic Flaw",
-    "Lost": 2000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/UnizenIO_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240307",
-    "name": "GHT",
-    "type": "Logic Flaw",
-    "Lost": 57000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/GHT_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240306",
-    "name": "ALP",
-    "type": "Access Control",
-    "Lost": 10000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/ALP_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240306",
-    "name": "TGBS",
-    "type": "Logic Flaw",
-    "Lost": 150000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/TGBS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240305",
-    "name": "Woofi",
-    "type": "Price Manipulation",
-    "Lost": 8000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-03/Woofi_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240228",
-    "name": "Seneca",
-    "type": "Arbitrary Call",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/Seneca_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240228",
-    "name": "SMOOFSStaking",
-    "type": "Reentrancy Attack",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/SMOOFSStaking_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20240223",
-    "name": "Zoomer",
-    "type": "Logic Flaw",
-    "Lost": 14.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-02/Zoomer_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240223",
-    "name": "CompoundUni",
-    "type": "Price Manipulation",
-    "Lost": 439537.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/CompoundUni_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240223",
-    "name": "BlueberryProtocol",
-    "type": "Logic Flaw",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/BlueberryProtocol_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240222",
-    "name": "SwarmMarkets",
-    "type": "Logic Flaw",
-    "Lost": 120000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/SwarmMarkets_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240221",
-    "name": "DeezNutz 404",
-    "type": "Logic Flaw",
     "Lost": 170000.0,
     "lossType": "USD",
-    "Contract": "src/test/2024-02/DeezNutz404_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240221",
-    "name": "GAIN",
-    "type": "Deflationary Token Incompatible",
-    "Lost": 6.4,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-02/GAIN_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240220",
-    "name": "EGGX",
-    "type": "Reentrancy Attack",
-    "Lost": 2.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-02/EGGX_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240219",
-    "name": "RuggedArt",
-    "type": "Reentrancy Attack",
-    "Lost": 10000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/RuggedArt_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240216",
-    "name": "ParticleTrade",
-    "type": "Incorrect Validation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/ParticleTrade_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240215",
-    "name": "DualPools",
-    "type": "Logic Flaw",
-    "Lost": 42000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/DualPools_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240215",
-    "name": "Babyloogn",
-    "type": "Logic Flaw",
-    "Lost": 2.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2024-02/Babyloogn_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240215",
-    "name": "Miner",
-    "type": "Incorrect Validation",
-    "Lost": 150000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/Miner_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240213",
-    "name": "MINER",
-    "type": "Price Manipulation",
-    "Lost": 3.5,
-    "lossType": "WBNB",
-    "Contract": "src/test/2024-02/MINER_bsc_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240211",
-    "name": "Game",
-    "type": "Reentrancy Attack",
-    "Lost": 20.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-02/Game_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240210",
-    "name": "FILX DN404",
-    "type": "Access Control",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/DN404_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240208",
-    "name": "Pandora",
-    "type": "Overflow",
-    "Lost": 17000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/PANDORA_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240205",
-    "name": "BurnsDefi",
-    "type": "Price Manipulation",
-    "Lost": 67000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/BurnsDefi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240202",
-    "name": "ADC",
-    "type": "Access Control",
-    "Lost": 20.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2024-02/ADC_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240201",
-    "name": "AffineDeFi",
-    "type": "Incorrect Validation",
-    "Lost": 88000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-02/AffineDeFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240130",
-    "name": "XSIJ",
-    "type": "Logic Flaw",
-    "Lost": 51000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/XSIJ_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240130",
-    "name": "MIMSpell_",
-    "type": "Precision Loss",
-    "Lost": 65000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/MIMSpell2_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240129",
-    "name": "PeapodsFinance",
-    "type": "Reentrancy Attack",
-    "Lost": 1000.0,
-    "lossType": "DAI",
-    "Contract": "src/test/2024-01/PeapodsFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240128",
-    "name": "BarleyFinance",
-    "type": "Reentrancy Attack",
-    "Lost": 130000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/BarleyFinance_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240127",
-    "name": "CitadelFinance",
-    "type": "Price Manipulation",
-    "Lost": 93000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/CitadelFinance_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240125",
-    "name": "NBLGAME",
-    "type": "Reentrancy Attack",
-    "Lost": 180000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/NBLGAME_exp.sol",
-    "chain": "Optimism"
-  },
-  {
-    "date": "20240122",
-    "name": "DAO_SoulMate",
-    "type": "Access Control",
-    "Lost": 319000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/DAO_SoulMate_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240117",
-    "name": "BmiZapper",
-    "type": "Incorrect Validation",
-    "Lost": 114000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/BmiZapper_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240115",
-    "name": "Shell_MEV_0xa898",
-    "type": "Access Control",
-    "Lost": 1000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/Shell_MEV_0xa898_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240112",
-    "name": "SocketGateway",
-    "type": "Incorrect Validation",
-    "Lost": 3300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/SocketGateway_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240112",
-    "name": "WiseLending",
-    "type": "Precision Loss",
-    "Lost": 464000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/WiseLending02_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240110",
-    "name": "Freedom",
-    "type": "Access Control",
-    "Lost": 74.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2024-01/Freedom_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240110",
-    "name": "LQDX",
-    "type": "Incorrect Validation",
-    "Lost": null,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/LQDX_alert_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20240104",
-    "name": "Gamma",
-    "type": "Price Manipulation",
-    "Lost": 6300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/Gamma_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240102",
-    "name": "MIC",
-    "type": "Logic Flaw",
-    "Lost": 500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/MIC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20240102",
-    "name": "RadiantCapital",
-    "type": "Logic Flaw",
-    "Lost": 4500000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/RadiantCapital_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20240101",
-    "name": "OrbitChain",
-    "type": "Incorrect Validation",
-    "Lost": 81000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2024-01/OrbitChain_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20251201",
-    "name": "yETH",
-    "type": "Unsafe Math",
-    "Lost": 9000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-12/yETH_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20251110",
-    "name": "DRLVaultV3",
-    "type": "Price Manipulation",
-    "Lost": 100000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-11/DRLVaultV3_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20251104",
-    "name": "Moonwell",
-    "type": "Faulty Oracle",
-    "Lost": 1000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-11/Moonwell_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20251103",
-    "name": "BalancerV2",
-    "type": "Precision Loss",
-    "Lost": 120000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-11/BalancerV2_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20251020",
-    "name": "SharwaFinance",
-    "type": "Post Insolvency Check",
-    "Lost": 146000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-10/SharwaFinance_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20251007",
-    "name": "TokenHolder",
-    "type": "Access Control",
-    "Lost": 20.0,
-    "lossType": "WBNB",
-    "Contract": "src/test/2025-10/TokenHolder_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20251004",
-    "name": "Abracadabra",
-    "type": "Logic Flaw",
-    "Lost": 1800000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-10/Abracadabra_exp.sol",
-    "chain": "Unknown"
-  },
-  {
-    "date": "20250913",
-    "name": "Kame",
-    "type": "Arbitary External Call",
-    "Lost": 18167.8,
-    "lossType": "USD",
-    "Contract": "src/test/2025-09/Kame_exp.sol",
-    "chain": "Sei"
-  },
-  {
-    "date": "20250831",
-    "name": "Hexotic",
-    "type": "Incorrect Input Validation",
-    "Lost": 500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/Hexotic_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250830",
-    "name": "EverValueCoin",
-    "type": "Arbitrage",
-    "Lost": 100000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/EverValueCoin",
-    "chain": "Unknown"
-  },
-  {
-    "date": "20250827",
-    "name": "0xf340",
-    "type": "Access Control",
-    "Lost": 4000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/0xf340_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250823",
-    "name": "ABCCApp",
-    "type": "Lack of Access Control",
-    "Lost": 10100.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/ABCCApp_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250820",
-    "name": "MulticallWithXera",
-    "type": "Access Control",
-    "Lost": 17000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/MulticallWithXera_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250820",
-    "name": "0x8d2e",
-    "type": "Access Control",
-    "Lost": 40000.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2025-08/0x8d2e_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20250816",
-    "name": "d3xai",
-    "type": "Price Manipulation",
-    "Lost": 190.0,
-    "lossType": "BNB",
-    "Contract": "src/test/2025-08/d3xai_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250815",
-    "name": "PDZ",
-    "type": "Price Manipulation",
-    "Lost": 3.3,
-    "lossType": "BNB",
-    "Contract": "src/test/2025-08/PDZ_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250815",
-    "name": "SizeCredit",
-    "type": "Access Control",
-    "Lost": 19700.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/SizeCredit_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250813",
-    "name": "YuliAI",
-    "type": "Price Manipulation",
-    "Lost": 78000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2025-08/YuliAI_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250813",
-    "name": "coinbase",
-    "type": "Misconfiguration",
-    "Lost": 300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/coinbase_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250813",
-    "name": "Grizzifi",
-    "type": "Logic Flaw",
-    "Lost": 61000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/Grizzifi_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250812",
-    "name": "Bebop",
-    "type": "Arbitrary user input",
-    "Lost": 21000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-08/Bebop_dex_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20250811",
-    "name": "WXC",
-    "type": "Incorrect token burn mechanism",
-    "Lost": 37.5,
-    "lossType": "WBNB",
-    "Contract": "src/test/2025-08/WXC_Token_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250728",
-    "name": "SuperRare",
-    "type": "Access Control",
-    "Lost": 730000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/SuperRare_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250726",
-    "name": "MulticallWithETH",
-    "type": "arbitrary-call",
-    "Lost": 10000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/MulticallWithETH_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250724",
-    "name": "SWAPPStaking",
-    "type": "Incorrect Reward calculation",
-    "Lost": 32196.28,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/SWAPPStaking_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250720",
-    "name": "Stepp2p",
-    "type": "Logic Flaw",
-    "Lost": 43000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/Stepp2p_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250717",
-    "name": "WETC",
-    "type": "Incorrect Burn Logic",
-    "Lost": 101000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/WETC_Token_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250716",
-    "name": "VDS",
-    "type": "Logic Flaw",
-    "Lost": 13000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/VDS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250709",
-    "name": "GMX",
-    "type": "Share price manipulation",
-    "Lost": 41000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/gmx_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20250705",
-    "name": "Unverified",
-    "type": "Access Control",
-    "Lost": 285700.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/unverified_54cd_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250705",
-    "name": "RANT",
-    "type": "Logic Flaw",
-    "Lost": 204000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-07/RANTToken_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250702",
-    "name": "FPC",
-    "type": "Logic Flaw",
-    "Lost": 4700000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2025-07/FPC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250629",
-    "name": "Stead",
-    "type": "Access Control",
-    "Lost": 14500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/Stead_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20250626",
-    "name": "ResupplyFi",
-    "type": "Share price manipulation",
-    "Lost": 9600000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/ResupplyFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250625",
-    "name": "Unverified_b5cb",
-    "type": "Access Control",
-    "Lost": 2000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/unverified_b5cb_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250623",
-    "name": "GradientMakerPool",
-    "type": "Price Oracle Manipulation",
-    "Lost": 5000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/GradientMakerPool_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250620",
-    "name": "Gangsterfinance",
-    "type": "Incorrect dividends",
-    "Lost": 16500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/Gangsterfinance_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250619",
-    "name": "BankrollStack",
-    "type": "Incorrect dividends calculation",
-    "Lost": 5000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/BankrollStack_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250619",
-    "name": "BankrollNetwork",
-    "type": "Incorrect dividends calculation",
-    "Lost": 24.5,
-    "lossType": "WBNB",
-    "Contract": "src/test/2025-06/BankrollNetwork_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250617",
-    "name": "MetaPool",
-    "type": "Access Control",
-    "Lost": 25000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/MetaPool_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250612",
-    "name": "AAVEBoost",
-    "type": "Logic Flaw",
-    "Lost": 14800.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/AAVEBoost_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250610",
-    "name": "Unverified_8490",
-    "type": "Access Control",
-    "Lost": 48300.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-06/unverified_8490_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250528",
-    "name": "Corkprotocol",
-    "type": "Access Control",
-    "Lost": 12000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/Corkprotocol_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250527",
-    "name": "UsualMoney",
-    "type": "Arbitrage",
-    "Lost": 43000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/UsualMoney_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20250526",
-    "name": "YDT",
-    "type": "Logic Flaw",
-    "Lost": 41000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/YDTtoken_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250524",
-    "name": "RICE",
-    "type": "Lack of Access Control",
-    "Lost": 88100.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/RICE_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20250520",
-    "name": "IRYSAI",
-    "type": "rug pull",
-    "Lost": 69600.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/IRYSAI_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250518",
-    "name": "KRC",
-    "type": "deflationary token",
-    "Lost": 7000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/KRCToken_pair_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20250514",
-    "name": "Unwarp",
-    "type": "lack-of-access-control",
-    "Lost": 9000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/Unwarp_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20250509",
-    "name": "Nalakuvara_LotteryTicket50",
-    "type": "Price Manipulation",
-    "Lost": 105500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2025-05/Nalakuvara_LotteryTicket50_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260112",
-    "name": "MTToken",
-    "type": "Incorrect Fee Logic",
-    "Lost": 37000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-01/MTToken_exp.sol",
-    "chain": "Unknown"
-  },
-  {
-    "date": "20260110",
-    "name": "FutureSwap",
-    "type": "Unit Mismatch",
-    "Lost": 433000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-01/futureswap_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20260109",
-    "name": "Truebit",
-    "type": "OverFlow",
-    "Lost": 8540.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-01/Truebit_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260101",
-    "name": "PRXVT",
-    "type": "Bussiness Logic Flaw",
-    "Lost": 32.8,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-01/PRXVT_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260120",
-    "name": "SynapLogic",
-    "type": "Business Logic Flaw",
-    "Lost": 27.6,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-01/SynapLogic_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260414",
-    "name": "MONA LisaVault",
-    "type": "reward-farming / BurnAddress accounting exploit!",
-    "Lost": 60950.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-04/MONA_LisaVault_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260414",
-    "name": "Saturn Protocol",
-    "type": "Vulnerability Disclosure",
-    "Lost": 0.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-04/SaturnProtocol_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260327",
-    "name": "EST Token",
-    "type": "Incorrect Token Burn Mechanism",
-    "Lost": 150.2,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-03/EST_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260315",
-    "name": "Venus THE",
-    "type": "BorrowBehalf + Donation Attack",
-    "Lost": 913858.2633605214,
-    "lossType": "CAKE",
-    "Contract": "src/test/2026-03/Venus_THE_exp.sol",
-    "chain": "Unknown"
-  },
-  {
-    "date": "20260310",
-    "name": "AlkemiEarn",
-    "type": "Business Logic",
-    "Lost": 43.45,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-03/AlkemiEarn_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260302",
-    "name": "Curve LlamaLend",
-    "type": "Share price manipulation",
-    "Lost": 240000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-03/Curve_LlamaLend_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260222",
-    "name": "LAXO Token",
-    "type": "Incorrect Burn Logic",
-    "Lost": 137000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-02/LAXO_Token_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260215",
-    "name": "Moonwell",
-    "type": "Faulty Oracle",
-    "Lost": 1780000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-02/Moonwell_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260617",
-    "name": "WHALE",
-    "type": "Transfer Accounting Reserve Desync",
-    "Lost": 3460.41,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/WHALE_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260617",
-    "name": "LBP",
-    "type": "LBP balanceOf reward accounting",
-    "Lost": 610.56,
-    "lossType": "BNB",
-    "Contract": "src/test/2026-06/LBP_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260616",
-    "name": "DIP",
-    "type": "Fee-on-Transfer Reserve Manipulation",
-    "Lost": 111097.59,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-06/DIP_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260615",
-    "name": "Thetanuts",
-    "type": "Index vault component-share accounting flaw",
-    "Lost": 105471.5,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-06/Thetanuts_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260614",
-    "name": "Aztec Connect",
-    "type": "numRealTxs Proof/Settlement Mismatch (permissionless RollupProcessorV3)",
-    "Lost": 2190000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/AztecConnect_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260609",
-    "name": "TOPBPool",
-    "type": "Governance-controlled token mint and Balancer pool drain",
-    "Lost": 944.2,
-    "lossType": "WETH",
-    "Contract": "src/test/2026-06/TOPBPool_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260609",
-    "name": "NovaBox",
-    "type": "Constructor Dividend Checkpoint Bypass",
-    "Lost": 56.73,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-06/NovaBox_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260607",
-    "name": "AmbientCrocSwapDex",
-    "type": "Native surplus accounting flaw",
-    "Lost": 67.85,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-06/AmbientCrocSwapDex_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260606",
-    "name": "BOSS",
-    "type": "BOSS helper mint/burn and transfer-tax pool skew",
-    "Lost": 10207.54,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/BOSS_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260605",
-    "name": "DTXT",
-    "type": "Liquidity Misclassification Fee Bypass",
-    "Lost": 35041.11,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/DTXT_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260605",
-    "name": "AISOTHPresale",
-    "type": "Fixed-price presale arbitrage",
-    "Lost": 30314.76,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/AISOTHPresale_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260604",
-    "name": "BYToken",
-    "type": "Permissionless triggerAutoBurn Reserve Manipulation",
-    "Lost": 87402.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/BYToken_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260530",
-    "name": "AROS",
-    "type": "Signature Replay",
-    "Lost": 295000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/AROS_exp.sol",
-    "chain": "Unknown"
-  },
-  {
-    "date": "20260529",
-    "name": "YSDAO",
-    "type": "Price Manipulation and Tax Bypass",
-    "Lost": 19490.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-05/YSDAO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260528",
-    "name": "LegendaryMoneyMonNft",
-    "type": "ecrecover address(0) Signature Bypass",
-    "Lost": 85500.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/LegendaryMoneyMonNft_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260528",
-    "name": "DxSale",
-    "type": "Ownership Override Attack",
-    "Lost": 7300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/DxSale_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260527",
-    "name": "Joe Agent",
-    "type": "Reentrancy in removeLiquidityViaContract",
-    "Lost": 45000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/JoeAgent_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260526",
-    "name": "SKP Token",
-    "type": "Owner Backdoor LP Burn + Price Manipulation",
-    "Lost": 212000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/SKP_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260525",
-    "name": "New Market Trading",
-    "type": "SquidRouterModule Missing Caller Check",
-    "Lost": 3980000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/NewMarketTrading_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260525",
-    "name": "WUSD.fi",
-    "type": "_englove Sybil Incentive Abuse",
-    "Lost": 200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/WUSD_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260522",
-    "name": "FractalProtocol",
-    "type": "Business Logic Flaw",
-    "Lost": 13700.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/FractalProtocol_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20260521",
-    "name": "MureDistribution",
-    "type": "Signature Verification Bypass",
-    "Lost": 5.45,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-05/MureDistribution_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260520",
-    "name": "MAPProtocol",
-    "type": "Arbitrary Mint",
-    "Lost": 180000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/MAPProtocol_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260517",
-    "name": "VerusBridge",
-    "type": "Insufficient Validation",
-    "Lost": 11580000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/VerusBridge_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260517",
-    "name": "SEAToken",
-    "type": "Business Logic Flaw",
-    "Lost": 110000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/SEAToken_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20260515",
-    "name": "AdsharesBridge",
-    "type": "Insufficient Validation",
-    "Lost": 628000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/AdsharesBridge_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260512",
-    "name": "SQTokenStaking",
-    "type": "Access Control",
-    "Lost": 346100.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/SQTokenStaking_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260511",
-    "name": "INKFinance",
-    "type": "Business Logic Flaw",
-    "Lost": 140000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/INKFinance_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260510",
-    "name": "Renegade",
-    "type": "Uninitialized Proxy",
-    "Lost": 209000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/Renegade_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20260507",
-    "name": "TrustedVolumes",
-    "type": "Signature Replay",
-    "Lost": 5870000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/TrustedVolumes_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260505",
-    "name": "Ekubo",
-    "type": "Business Logic Flaw",
-    "Lost": 1400000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/Ekubo_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260624",
-    "name": "DLMC",
-    "type": "Reserve-derived livePrice manipulation",
-    "Lost": 222560.22,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/DLMC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260623",
-    "name": "RoyalRoyalties",
-    "type": "Zero-amount ERC1155 batch transfer inflated Royal LDA tier balance",
-    "Lost": 261162.93,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260620",
-    "name": "OLPC",
-    "type": "OLPC pair reserve manipulation",
-    "Lost": 1115903.66,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/OLPC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260618",
-    "name": "JB",
-    "type": "JB helper repeated cycle drains JB/USDT pair",
-    "Lost": 49958.06,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-06/JB_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260617",
-    "name": "Aztec V1",
-    "type": "escapeHatch Proof-Forgery (permissionless RollupProcessor exit)",
-    "Lost": 2200000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/AztecEscapeHatch_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260525",
-    "name": "SquidRouterModule",
-    "type": "Missing caller check",
-    "Lost": 0.25,
-    "lossType": "WBTC",
-    "Contract": "src/test/2026-05/SquidRouterModule_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260519",
-    "name": "ElevateFi",
-    "type": "Reserve Price Manipulation",
-    "Lost": 16000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/ElevateFi_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260518",
-    "name": "TesseraSwap",
-    "type": "Callback Repayment Price Spread",
-    "Lost": 20000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/TesseraSwap_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260511",
-    "name": "HumaFinance",
-    "type": "Credit Approval Bypass",
-    "Lost": 101000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-05/HumaCreditApprovalBypass_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260428",
-    "name": "RWAVault",
-    "type": "Missing ERC4626 allowance check",
-    "Lost": 398655.47,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-04/RWAVault_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260425",
-    "name": "SingularityDynaVault",
-    "type": "Oracle Misconfiguration / Share Inflation",
-    "Lost": 413130.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-04/SingularityDynaVault_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260421",
-    "name": "KipseliPropAMM",
-    "type": "Pricing / Decimals Mismatch",
-    "Lost": 0.93,
-    "lossType": "CBBTC",
-    "Contract": "src/test/2026-04/KipseliPropAMM_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260420",
-    "name": "JuiceboxREVLoans",
-    "type": "Fake terminal loan source validation bypass",
-    "Lost": 21.77,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-04/JuiceboxREVLoans_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260420",
-    "name": "ThetanutsVaultShareRounding",
-    "type": "Vault Share Rounding Manipulation",
-    "Lost": 0.15,
-    "lossType": "WBTC",
-    "Contract": "src/test/2026-04/ThetanutsVaultShareRounding_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260415",
-    "name": "XLootStaking",
-    "type": "Duplicate xLOOT Redemption",
-    "Lost": 6.21,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-04/XLootStaking_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260412",
-    "name": "SubQuerySettings",
-    "type": "Settings access control",
-    "Lost": 218070000.0,
-    "lossType": "SQT",
-    "Contract": "src/test/2026-04/SubQuerySettings_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260407",
-    "name": "SquidMulticallAllowanceDrain",
-    "type": "Arbitrary Call / Wrong Approval",
-    "Lost": 1.0,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-04/SquidMulticallAllowanceDrain_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260405",
-    "name": "PerpPair",
-    "type": "Virtual AMM Manipulation",
-    "Lost": 165000.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-04/PerpPair_exp.sol",
-    "chain": "Linea"
-  },
-  {
-    "date": "20260331",
-    "name": "WhalebitOracleManipulation",
-    "type": "Algebra spot-price oracle manipulation",
-    "Lost": 824000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-03/WhalebitOracleManipulation_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260216",
-    "name": "XDKRecycle",
-    "type": "XDK recycle reserve manipulation",
-    "Lost": 6.84,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-02/XDKRecycle_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260625",
-    "name": "LixirPermitDrain",
-    "type": "Broken Signature Verification",
-    "Lost": 2.6,
-    "lossType": "ETH",
-    "Contract": "src/test/2026-06/LixirPermitDrain_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260625",
-    "name": "OceanBPoolSideStaking",
-    "type": "BPool single-sided join/exit math with SideStaking gulp accounting",
-    "Lost": 127860.0,
-    "lossType": "MOCEAN",
-    "Contract": "src/test/2026-06/OceanBPoolSideStaking_exp.sol",
-    "chain": "Polygon"
-  },
-  {
-    "date": "20260501",
-    "name": "SharwaMarginTrading",
-    "type": "Hegic collateral spot price manipulation",
-    "Lost": 32850.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-05/SharwaMarginTrading_exp.sol",
-    "chain": "Arbitrum"
-  },
-  {
-    "date": "20260428",
-    "name": "JUDAO",
-    "type": "JUDAO sell-hook reserve drain",
-    "Lost": 205000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-04/JUDAO_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260427",
-    "name": "Unverified_a152",
-    "type": "AllowanceTarget approval drain",
-    "Lost": 229000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-04/unverified_a152_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260423",
-    "name": "GiddyVaultV3",
-    "type": "Incomplete Signature Coverage",
-    "Lost": 1300000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-04/giddyvaultv3_compound_auth_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260419",
-    "name": "AaveRebalancerCreditDelegation",
-    "type": "Arbitrary External Call / Credit Delegation Abuse",
-    "Lost": 6999.91,
-    "lossType": "WAVAX",
-    "Contract": "src/test/2026-04/AaveRebalancerCreditDelegation_exp.sol",
+    "Contract": "src/test/2022-12/Defrost_exp.sol",
     "chain": "Avalanche"
   },
   {
-    "date": "20260324",
-    "name": "XocolatlLiquidator",
-    "type": "Access Control / Input Validation",
-    "Lost": 3.25,
-    "lossType": "CBETH",
-    "Contract": "src/test/2026-03/XocolatlLiquidator_exp.sol",
-    "chain": "Base"
+    "date": "20221214",
+    "name": "Nmbplatform",
+    "type": "Price Manipulation",
+    "Lost": 76000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/Nmbplatform_exp.sol",
+    "chain": "BSC"
   },
   {
-    "date": "20260328",
-    "name": "VTSwapHook",
-    "type": "Pricing Error in UniswapV4 Hook",
-    "Lost": 4507034.03,
-    "lossType": "VATH",
-    "Contract": "src/test/2026-03/VTSwapHook_exp.sol",
+    "date": "20221214",
+    "name": "FPR",
+    "type": "Access Control",
+    "Lost": 29000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/FPR_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221213",
+    "name": "ElasticSwap",
+    "type": "Logic Flaw",
+    "Lost": 845000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/ElasticSwap_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221212",
+    "name": "BGLD (Deflationary token)",
+    "type": "Price Manipulation",
+    "Lost": 18000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/BGLD_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221211",
+    "name": "Lodestar",
+    "type": "Price Manipulation",
+    "Lost": 4000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/Lodestar_exp.sol",
     "chain": "Arbitrum"
   },
   {
-    "date": "20260324",
-    "name": "Univ3CollateralToken",
-    "type": "Logic Error",
+    "date": "20221211",
+    "name": "MEVbot_0x28d9",
+    "type": "Logic Flaw",
+    "Lost": 2000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/MEVbot_0x28d9_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221210",
+    "name": "MU&MUG",
+    "type": "Price Manipulation",
     "Lost": 57000.0,
     "lossType": "USD",
-    "Contract": "src/test/2026-03/Univ3CollateralToken_exp.sol",
+    "Contract": "src/test/2022-12/MUMUG_exp.sol",
+    "chain": "Avalanche"
+  },
+  {
+    "date": "20221210",
+    "name": "TIFIToken",
+    "type": "Price Manipulation",
+    "Lost": 87.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2022-12/TIFI_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221209",
+    "name": "NOVAToken",
+    "type": "Social Engineering",
+    "Lost": 330.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-12/NovaExchange_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221207",
+    "name": "AES (Deflationary token)",
+    "type": "Price Manipulation",
+    "Lost": 60000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/AES_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221205",
+    "name": "RFB",
+    "type": "Weak RNG",
+    "Lost": 12.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-12/RFB_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221205",
+    "name": "BBOX",
+    "type": "Price Manipulation",
+    "Lost": 12000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/BBOX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221202",
+    "name": "OverNight",
+    "type": "Flash Loan Attack",
+    "Lost": 170000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/Overnight_exp.sol",
+    "chain": "Avalanche"
+  },
+  {
+    "date": "20221201",
+    "name": "APC",
+    "type": "Price Manipulation",
+    "Lost": 6000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-12/APC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221129",
+    "name": "MBC & ZZSH",
+    "type": "Access Control",
+    "Lost": 5600.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/MBC_ZZSH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221129",
+    "name": "SEAMAN",
+    "type": "Logic Flaw",
+    "Lost": 7000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/SEAMAN_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221123",
+    "name": "NUM",
+    "type": "Token Incompatible",
+    "Lost": 13000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/NUM_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221122",
+    "name": "AUR",
+    "type": "Access Control",
+    "Lost": 13000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/AUR_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221121",
+    "name": "sDAO",
+    "type": "Logic Flaw",
+    "Lost": 13000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/SDAO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221119",
+    "name": "AnnexFinance",
+    "type": "Flash Loan Attack",
+    "Lost": 3000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/Annex_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221118",
+    "name": "Polynomial",
+    "type": "Logic Flaw",
+    "Lost": 1400.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/Polynomial_exp.sol",
     "chain": "Optimism"
   },
   {
-    "date": "20260323",
-    "name": "BCE",
-    "type": "Deflationary Token Logic Error",
-    "Lost": 800000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-03/bce_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260319",
-    "name": "ATMBlindBox",
-    "type": "Weak Randomness / Predictable RNG",
-    "Lost": 99000.0,
+    "date": "20221117",
+    "name": "UEarnPool",
+    "type": "Flash Loan Attack",
+    "Lost": 24000.0,
     "lossType": "USD",
-    "Contract": "src/test/2026-03/ATMBlindBox_exp.sol",
+    "Contract": "src/test/2022-11/UEarnPool_exp.sol",
     "chain": "BSC"
   },
   {
-    "date": "20260319",
-    "name": "Revamp",
-    "type": "Reward Accounting Drain",
-    "Lost": 2.99,
+    "date": "20221116",
+    "name": "SheepFarm",
+    "type": "Logic Flaw",
+    "Lost": 1.0,
     "lossType": "BNB",
-    "Contract": "src/test/2026-03/Revamp_exp.sol",
+    "Contract": "src/test/2022-11/SheepFarm_exp.sol",
     "chain": "BSC"
   },
   {
-    "date": "20260316",
-    "name": "unverified",
-    "type": "CheckoutPool Old BOC Missing Access Control",
-    "Lost": 85730.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-03/unverified_1304_exp.sol",
+    "date": "20221110",
+    "name": "DFXFinance",
+    "type": "Reentrancy Attack",
+    "Lost": 4000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/DFX_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221109",
+    "name": "BrahTOPG",
+    "type": "Incorrect Validation",
+    "Lost": 89000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/BrahTOPG_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221108",
+    "name": "MEV_0ad8",
+    "type": "Arbitrary Call",
+    "Lost": 282000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/MEV_0ad8_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221108",
+    "name": "Kashi",
+    "type": "Logic Flaw",
+    "Lost": 110000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/Kashi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221107",
+    "name": "MooCAKECTX",
+    "type": "Flash Loan Attack",
+    "Lost": 140000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-11/MooCAKECTX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221105",
+    "name": "BDEX",
+    "type": "Logic Flaw",
+    "Lost": 16.0,
+    "lossType": "WBNB",
+    "Contract": "src/test/2022-11/BDEX_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221027",
+    "name": "VTF Token",
+    "type": "Logic Flaw",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/VTF_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221027",
+    "name": "Team Finance",
+    "type": "Incorrect Validation",
+    "Lost": 15800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/TeamFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221026",
+    "name": "N00d Token",
+    "type": "Reentrancy Attack",
+    "Lost": 29000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/N00d_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221025",
+    "name": "ULME",
+    "type": "Access Control",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/ULME_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221024",
+    "name": "Market",
+    "type": "Reentrancy Attack",
+    "Lost": 220000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/Market_exp.sol",
     "chain": "Polygon"
   },
   {
-    "date": "20260315",
-    "name": "StakeOnMe",
-    "type": "Owner-privileged JAKE burn reserve drain",
-    "Lost": 0.28,
+    "date": "20221024",
+    "name": "MulticallWithoutCheck",
+    "type": "Arbitrary Call",
+    "Lost": 600.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/MulticallWithoutCheck_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20221021",
+    "name": "OlympusDAO",
+    "type": "Incorrect Validation",
+    "Lost": 292000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/OlympusDao_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221020",
+    "name": "HEALTH",
+    "type": "Logic Flaw",
+    "Lost": 16.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-10/HEALTH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221020",
+    "name": "BEGO",
+    "type": "Signature Verification",
+    "Lost": 12.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-10/BEGO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221018",
+    "name": "HPAY",
+    "type": "Access Control",
+    "Lost": 115.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-10/HPAY_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221018",
+    "name": "PLTD",
+    "type": "Logic Flaw",
+    "Lost": 24000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/PLTD_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221017",
+    "name": "Uerii Token",
+    "type": "Access Control",
+    "Lost": 2400.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/Uerii_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221014",
+    "name": "INUKO",
+    "type": "Price Manipulation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/INUKO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221014",
+    "name": "EFLeverVault",
+    "type": "Flash Loan Attack",
+    "Lost": 750.0,
     "lossType": "ETH",
-    "Contract": "src/test/2026-03/unverified_237d_exp.sol",
+    "Contract": "src/test/2022-10/EFLeverVault_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221014",
+    "name": "MEVBOTa47b",
+    "type": "Front-running Attack",
+    "Lost": 241000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/MEVa47b_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221012",
+    "name": "ATK",
+    "type": "Flash Loan Attack",
+    "Lost": 127000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/ATK_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221011",
+    "name": "Rabby Wallet SwapRouter",
+    "type": "Arbitrary Call",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/RabbyWallet_SwapRouter_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221011",
+    "name": "Templedao",
+    "type": "Access Control",
+    "Lost": 2300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/Templedao_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221010",
+    "name": "Carrot",
+    "type": "Access Control",
+    "Lost": 31318.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/Carrot_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221009",
+    "name": "Xave Finance",
+    "type": "Access Control",
+    "Lost": 700.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/XaveFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20221006",
+    "name": "RES-Token",
+    "type": "Price Manipulation",
+    "Lost": 290000,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/RES_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221002",
+    "name": "Transit Swap",
+    "type": "Incorrect Validation",
+    "Lost": 21000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/TransitSwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221001",
+    "name": "BabySwap",
+    "type": "Access Control",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/BabySwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221001",
+    "name": "RL Token",
+    "type": "Logic Flaw",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-10/RL_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20221001",
+    "name": "Thunder Brawl",
+    "type": "Reentrancy Attack",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/THB_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220928",
+    "name": "BXH",
+    "type": "Flash Loan Attack",
+    "Lost": 40305.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/BXH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220928",
+    "name": "MEVBOT_0xbaDc0dE",
+    "type": "Sandwich Attack",
+    "Lost": 94304.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/MEVbadc0de_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220923",
+    "name": "RADT-DAO",
+    "type": "Price Manipulation",
+    "Lost": 94304.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/RADT_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220913",
+    "name": "MevBot private tx",
+    "type": "Access Control",
+    "Lost": 140000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/BNB48MEVBot_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220909",
+    "name": "DPC",
+    "type": "Logic Flaw",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/DPC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220908",
+    "name": "YYDS",
+    "type": "Price Manipulation",
+    "Lost": 742286.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/Yyds_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220908",
+    "name": "Ragnarok Online Invasion",
+    "type": "Access Control",
+    "Lost": 44000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/ROI_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220908",
+    "name": "NewFreeDAO",
+    "type": "Flash Loan Attack",
+    "Lost": 125000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/NewFreeDAO_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220906",
+    "name": "NXUSD",
+    "type": "Flash Loan Attack",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/NXUSD_exp.sol",
+    "chain": "Avalanche"
+  },
+  {
+    "date": "20220905",
+    "name": "ZoomproFinance",
+    "type": "Price Manipulation",
+    "Lost": 61160.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/ZoomproFinance_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220902",
+    "name": "ShadowFi",
+    "type": "Access Control",
+    "Lost": 1078.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-09/Shadowfi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220902",
+    "name": "Bad Guys by RPF",
+    "type": "Incorrect Validation",
+    "Lost": 400.0,
+    "lossType": "RPF",
+    "Contract": "src/test/2022-09/BadGuysbyRPF_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220828",
+    "name": "DDC",
+    "type": "Access Control",
+    "Lost": 100000,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/DDC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220824",
+    "name": "LuckyTiger NFT",
+    "type": "Weak RNG",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/LuckyTiger_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220816",
+    "name": "Circle_",
+    "type": "Price Manipulation",
+    "Lost": 151600.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/Circle_exp2.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220813",
+    "name": "Circle",
+    "type": "Price Manipulation",
+    "Lost": 50500.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/Circle_exp1.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220810",
+    "name": "XSTABLE Protocol",
+    "type": "Logic Flaw",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/XST_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220809",
+    "name": "ANCH",
+    "type": "Incorrect Validation",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/ANCH_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220807",
+    "name": "EGD Finance",
+    "type": "Price Manipulation",
+    "Lost": 36044.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/EGD_Finance_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220804",
+    "name": "EtnProduct",
+    "type": "Logic Flaw",
+    "Lost": 3074.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/EtnProduct_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220803",
+    "name": "Qixi",
+    "type": "Overflow",
+    "Lost": 6.08,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-08/Qixi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220802",
+    "name": "Nomad Bridge",
+    "type": "Incorrect Validation",
+    "Lost": 152000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/NomadBridge_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220801",
+    "name": "Reaper Farm",
+    "type": "Access Control",
+    "Lost": 1700000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-08/ReaperFarm_exp.sol",
+    "chain": "Fantom"
+  },
+  {
+    "date": "20220725",
+    "name": "LPC",
+    "type": "Incorrect Validation",
+    "Lost": 45000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/LPC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220723",
+    "name": "Audius",
+    "type": "Storage Collision",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/Audius_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220713",
+    "name": "SpaceGodzilla",
+    "type": "Price Manipulation",
+    "Lost": 26000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/SpaceGodzilla_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220710",
+    "name": "Omni NFT",
+    "type": "Reentrancy Attack",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/Omni_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220706",
+    "name": "FlippazOne NFT",
+    "type": "Access Control",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/FlippazOne_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220701",
+    "name": "Quixotic",
+    "type": "Incorrect Validation",
+    "Lost": 100000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-07/Quixotic_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220626",
+    "name": "XCarnival",
+    "type": "Flash Loan Attack",
+    "Lost": 3870000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-06/XCarnival_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220624",
+    "name": "Harmony's Horizon Bridge",
+    "type": "Private Key Compromised",
+    "Lost": 100000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-06/Harmony_multisig_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220618",
+    "name": "SNOOD",
+    "type": "Incorrect Validation",
+    "Lost": 104.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2022-06/Snood_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220616",
+    "name": "InverseFinance",
+    "type": "Flash Loan Attack",
+    "Lost": 1260000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-06/InverseFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220608",
+    "name": "GYMNetwork_",
+    "type": "Access Control",
+    "Lost": 2000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-06/Gym_2_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220608",
+    "name": "Optimism-Wintermute",
+    "type": "Bridge Attack",
+    "Lost": 20000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-06/Optimism_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220606",
+    "name": "Discover",
+    "type": "Flash Loan Attack",
+    "Lost": 49.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-06/Discover_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220529",
+    "name": "NOVO Protocol",
+    "type": "Flash Loan Attack",
+    "Lost": 279.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-05/Novo_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220524",
+    "name": "HackDao",
+    "type": "Logic Flaw",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-05/HackDao_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220517",
+    "name": "ApeCoin (APE)",
+    "type": "Flash Loan Attack",
+    "Lost": 1100000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-05/Bayc_apecoin_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220508",
+    "name": "Fortress Loans",
+    "type": "Price Manipulation",
+    "Lost": 3000000.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2022-05/FortressLoans_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220430",
+    "name": "Saddle Finance",
+    "type": "Swap Metapool Attack",
+    "Lost": 10000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/Saddle_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220430",
+    "name": "Rari Capital/Fei Protocol",
+    "type": "Reentrancy Attack",
+    "Lost": 80000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/Rari_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220428",
+    "name": "DEUS DAO",
+    "type": "Flash Loan Attack",
+    "Lost": 13000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/deus_exp.sol",
+    "chain": "Fantom"
+  },
+  {
+    "date": "20220424",
+    "name": "Wiener DOGE",
+    "type": "Flash Loan Attack",
+    "Lost": 78.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-04/Wdoge_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220423",
+    "name": "Akutar NFT",
+    "type": "Denial Of Service",
+    "Lost": 34000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/AkutarNFT_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220421",
+    "name": "Zeed Finance",
+    "type": "Logic Flaw",
+    "Lost": 1000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/Zeed_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220416",
+    "name": "BeanstalkFarms",
+    "type": "Flash Loan Attack",
+    "Lost": 182000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/Beanstalk_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220415",
+    "name": "Rikkei Finance",
+    "type": "Access Control",
+    "Lost": 1100000.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2022-04/Rikkei_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220412",
+    "name": "ElephantMoney",
+    "type": "Flash Loan Attack",
+    "Lost": 11200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/Elephant_Money_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220411",
+    "name": "Creat Future",
+    "type": "Overflow",
+    "Lost": 1900000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-04/cftoken_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220409",
+    "name": "GYMNetwork",
+    "type": "Flash Loan Attack",
+    "Lost": 1327,
+    "lossType": "WBNB",
+    "Contract": "src/test/2022-04/Gym_1_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220329",
+    "name": "Ronin Network",
+    "type": "Bridge Attack",
+    "Lost": 624000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Ronin_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220329",
+    "name": "Redacted Cartel",
+    "type": "Logic Flaw",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/RedactedCartel_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220327",
+    "name": "Revest Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 11200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Revest_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220326",
+    "name": "Auctus",
+    "type": "Arbitrary Call",
+    "Lost": 726000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Auctus_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220322",
+    "name": "CompoundTUSDSweepTokenBypass",
+    "type": "Incorrect Validation",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/CompoundTusd_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220321",
+    "name": "OneRing Finance",
+    "type": "Flash Loan Attack",
+    "Lost": 1450000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/OneRing_exp.sol",
+    "chain": "Fantom"
+  },
+  {
+    "date": "20220320",
+    "name": "Li.Fi",
+    "type": "Bridge Attack",
+    "Lost": 570000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/LiFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220320",
+    "name": "Umbrella Network",
+    "type": "Overflow",
+    "Lost": 700000,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Umbrella_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220315",
+    "name": "Agave Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 1500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Agave_exp.sol",
+    "chain": "Gnosis"
+  },
+  {
+    "date": "20220313",
+    "name": "Hundred Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 1700000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/HundredFinance_exp.sol",
+    "chain": "Gnosis"
+  },
+  {
+    "date": "20220313",
+    "name": "Paraluni",
+    "type": "Reentrancy Attack",
+    "Lost": 1700000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Paraluni_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20220309",
+    "name": "Fantasm Finance",
+    "type": "Logic Flaw",
+    "Lost": 2600000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Fantasm_exp.sol",
+    "chain": "Fantom"
+  },
+  {
+    "date": "20220305",
+    "name": "Bacon Protocol",
+    "type": "Reentrancy Attack",
+    "Lost": 1000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/Bacon_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220303",
+    "name": "TreasureDAO",
+    "type": "Incorrect Validation",
+    "Lost": 470000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-03/TreasureDAO_exp.sol",
+    "chain": "Arbitrum"
+  },
+  {
+    "date": "20220214",
+    "name": "BuildFinance",
+    "type": "Governance Attack",
+    "Lost": 470000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-02/BuildF_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220208",
+    "name": "Sandbox LAND",
+    "type": "Access Control",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2022-02/Sandbox_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220206",
+    "name": "Meter",
+    "type": "Bridge Attack",
+    "Lost": 4300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-02/meter_exp.sol",
+    "chain": "Moonriver"
+  },
+  {
+    "date": "20220204",
+    "name": "TecraSpace",
+    "type": "Logic Flaw",
+    "Lost": 63000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-02/TecraSpace_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220128",
+    "name": "Qubit Finance",
+    "type": "Bridge Attack",
+    "Lost": 80000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-01/Qubit_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20220118",
+    "name": "Multichain (Anyswap)",
+    "type": "Incorrect Validation",
+    "Lost": 1400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2022-01/Anyswap_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20211221",
+    "name": "Visor Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 8199999.999999999,
+    "lossType": "USD",
+    "Contract": "src/test/2021-12/Visor_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20211218",
+    "name": "Grim Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 30000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-12/Grim_exp.sol",
+    "chain": "Fantom"
+  },
+  {
+    "date": "20211214",
+    "name": "Nerve Bridge",
+    "type": "Swap Metapool Attack",
+    "Lost": 900.0,
+    "lossType": "BNB",
+    "Contract": "src/test/2021-12/NerveBridge_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20211130",
+    "name": "MonoX Finance",
+    "type": "Price Manipulation",
+    "Lost": 31000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-11/Mono_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20211123",
+    "name": "Ploutoz",
+    "type": "Flash Loan Attack",
+    "Lost": 365000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-11/Ploutoz_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20211027",
+    "name": "CreamFinance",
+    "type": "Price Manipulation",
+    "Lost": 130000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-10/Cream_2_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20211015",
+    "name": "Indexed Finance",
+    "type": "Price Manipulation",
+    "Lost": 16000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-10/IndexedFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210916",
+    "name": "SushiSwap Miso",
+    "type": "Incorrect Validation",
+    "Lost": 3000000,
+    "lossType": "USD",
+    "Contract": "src/test/2021-09/Sushimiso_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210915",
+    "name": "Nimbus Platform",
+    "type": "Logic Flaw",
+    "Lost": 1.45,
+    "lossType": "ETH",
+    "Contract": "src/test/2021-09/Nimbus_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210915",
+    "name": "NowSwap Platform",
+    "type": "Logic Flaw",
+    "Lost": 1000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-09/NowSwap_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210912",
+    "name": "ZABU Finance",
+    "type": "Deflationary Token Incompatible",
+    "Lost": 3200000,
+    "lossType": "USD",
+    "Contract": "src/test/2021-09/ZABU_exp.sol",
+    "chain": "Avalanche"
+  },
+  {
+    "date": "20210903",
+    "name": "DAO Maker",
+    "type": "Access Control",
+    "Lost": 4000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-09/DaoMaker_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210830",
+    "name": "Cream Finance",
+    "type": "Reentrancy Attack",
+    "Lost": 18000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-08/Cream_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210817",
+    "name": "XSURGE",
+    "type": "Reentrancy Attack",
+    "Lost": 5000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-08/XSURGE_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210811",
+    "name": "Poly Network",
+    "type": "Bridge Attack",
+    "Lost": 611000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-08/PolyNetwork_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210804",
+    "name": "WaultFinace",
+    "type": "Price Manipulation",
+    "Lost": 390.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2021-08/WaultFinance_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210728",
+    "name": "Levyathan Finance",
+    "type": "Private Key Compromised",
+    "Lost": 1500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-07/Levyathan_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210710",
+    "name": "Chainswap_",
+    "type": "Logic Flaw",
+    "Lost": 4400000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-07/Chainswap_exp2.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210702",
+    "name": "Chainswap",
+    "type": "Logic Flaw",
+    "Lost": 800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-07/Chainswap_exp1.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210628",
+    "name": "SafeDollar",
+    "type": "Deflationary Token Incompatible",
+    "Lost": 200000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-06/SafeDollar_exp.sol",
+    "chain": "Polygon"
+  },
+  {
+    "date": "20210625",
+    "name": "xWin Finance",
+    "type": "Logic Flaw",
+    "Lost": 300000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-06/xWin_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210622",
+    "name": "Eleven Finance",
+    "type": "Logic Flaw",
+    "Lost": 4500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-06/Eleven_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210607",
+    "name": "88mph NFT",
+    "type": "Access Control",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2021-06/88mph_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210603",
+    "name": "PancakeHunny",
+    "type": "Logic Flaw",
+    "Lost": 43,
+    "lossType": "ETH",
+    "Contract": "src/test/2021-06/PancakeHunny_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210527",
+    "name": "JulSwap",
+    "type": "Flash Loan Attack",
+    "Lost": 1500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/JulSwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210527",
+    "name": "BurgerSwap",
+    "type": "Reentrancy Attack",
+    "Lost": 7000000,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/BurgerSwap_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210519",
+    "name": "PancakeBunny",
+    "type": "Price Manipulation",
+    "Lost": 45000000,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/PancakeBunny_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210516",
+    "name": "bEarn",
+    "type": "Logic Flaw",
+    "Lost": 11000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/bEarn_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210509",
+    "name": "RariCapital",
+    "type": "Reentrancy Attack",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/RariCapital_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210508",
+    "name": "Value Defi",
+    "type": "Reentrancy Attack",
+    "Lost": 10000000,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/ValueDefi_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210502",
+    "name": "Spartan",
+    "type": "Logic Flaw",
+    "Lost": 30500000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-05/Spartan_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210428",
+    "name": "Uranium",
+    "type": "Logic Flaw",
+    "Lost": 50000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-04/Uranium_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20210308",
+    "name": "DODO",
+    "type": "Flash Loan Attack",
+    "Lost": 700000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-03/dodo_flashloan_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210305",
+    "name": "Paid Network",
+    "type": "Private Key Compromised",
+    "Lost": 3000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-03/PAID_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210204",
+    "name": "Yearn YDai",
+    "type": "Slippage",
+    "Lost": 11000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2021-02/Yearn_ydai_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20210125",
+    "name": "Sushi Badger Digg",
+    "type": "Sandwich Attack",
+    "Lost": 81.68,
+    "lossType": "ETH",
+    "Contract": "src/test/2021-01/Sushi_Badger_Digg_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20201229",
+    "name": "Cover Protocol",
+    "type": "Logic Flaw",
+    "Lost": null,
+    "lossType": "USD",
+    "Contract": "src/test/2020-12/Cover_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20201121",
+    "name": "Pickle Finance",
+    "type": "Incorrect Validation",
+    "Lost": 20000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2020-11/Pickle_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20201026",
+    "name": "Harvest Finance",
+    "type": "Flash Loan Attack",
+    "Lost": 33800000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2020-10/HarvestFinance_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200912",
+    "name": "bzx",
+    "type": "Logic Flaw",
+    "Lost": 8100000,
+    "lossType": "USD",
+    "Contract": "src/test/2020-09/bzx_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200804",
+    "name": "Opyn Protocol",
+    "type": "Logic Flaw",
+    "Lost": 370000,
+    "lossType": "USD",
+    "Contract": "src/test/2020-08/Opyn_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200628",
+    "name": "Balancer Protocol",
+    "type": "Token Incompatible",
+    "Lost": 500000,
+    "lossType": "USD",
+    "Contract": "src/test/2020-06/Balancer_20200628_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200618",
+    "name": "Bancor Protocol",
+    "type": "Access Control",
+    "Lost": 545000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2020-06/Bancor_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200419",
+    "name": "LendfMe",
+    "type": "Reentrancy Attack",
+    "Lost": 25000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2020-04/LendfMe_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20200418",
+    "name": "UniSwapV1",
+    "type": "Reentrancy Attack",
+    "Lost": 220000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2020-04/uniswap-erc777.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20181007",
+    "name": "SpankChain",
+    "type": "Reentrancy Attack",
+    "Lost": 155.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2018-10/SpankChain_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20180424",
+    "name": "SmartMesh",
+    "type": "Overflow",
+    "Lost": 140000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2018-04/SmartMesh_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20180422",
+    "name": "Beauty Chain",
+    "type": "Overflow",
+    "Lost": 900000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2018-04/BEC_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20171106",
+    "name": "Parity",
+    "type": "Access Control",
+    "Lost": 514000.0,
+    "lossType": "ETH",
+    "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -5212,5 +5212,13 @@
     "images": [],
     "Lost": "",
     "Contract": "https://github.com/SunWeb3Sec/DeFiHackLabs/blob/main/src/test/2026-06/LBP_exp.sol"
+  },
+  "JaredFromSubway": {
+    "type": "MEV Exploit",
+    "date": "2026-06-20",
+    "rootCause": "JaredFromSubway MEV bot was exploited, resulting in a loss of 4,424 ETH (~$7.5M). Analysis: https://www.certik.com/blog/jaredfromsubway-mev-bot-incident-analysis\n\n**Source:** [https://twitter.com/CertiKAlert/status/2070478621139935316](https://twitter.com/CertiKAlert/status/2070478621139935316)",
+    "images": [],
+    "Lost": "4424.00 ETH",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-06-26.

Added **1** new incident(s): JaredFromSubway

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| JaredFromSubway | Ethereum | MEV Exploit | 4424 ETH |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
