### PR TITLE
feat: add Discord-sourced incidents 2026-07-02

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,32 @@
 [
   {
+    "date": "20260702",
+    "name": "EdelFinance",
+    "type": "Collateral Price Manipulation",
+    "Lost": 353000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260702",
+    "name": "Taiko",
+    "type": "Unknown",
+    "Lost": 180.0,
+    "lossType": "ETH",
+    "Contract": "",
+    "chain": "Taiko"
+  },
+  {
+    "date": "20260702",
+    "name": "AztecNetwork",
+    "type": "Bridge Exploit",
+    "Lost": 200.0,
+    "lossType": "ETH",
+    "Contract": "",
+    "chain": "Aztec"
+  },
+  {
     "date": "20260629",
     "name": "AIDC",
     "type": "Smart Contract Logic Flaw",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6283,5 +6283,29 @@
     "images": [],
     "Lost": "220.12 WBNB",
     "Contract": ""
+  },
+  "EdelFinance": {
+    "type": "Collateral Price Manipulation",
+    "date": "2026-07-02",
+    "rootCause": "Attacker manipulated the wGOOGLx collateral price, which is derived from its underlying GOOGLx balance, allowing them to borrow against the inflated collateral and drain approximately $353K. Stolen assets were swapped for 224 ETH and deposited into Tornado Cash.\n\n**Source:** [https://twitter.com/CyversAlerts/status/2072259516435939780](https://twitter.com/CyversAlerts/status/2072259516435939780)",
+    "images": [],
+    "Lost": "$353.0K",
+    "Contract": ""
+  },
+  "Taiko": {
+    "type": "Unknown",
+    "date": "2026-07-02",
+    "rootCause": "Taiko exploiter deposited 180 ETH (~$288K) into Tornado Cash. Alert indicates additional fund mixing from an exploit.\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2072486031707005283](https://twitter.com/PeckShieldAlert/status/2072486031707005283)",
+    "images": [],
+    "Lost": "180.00 ETH",
+    "Contract": ""
+  },
+  "AztecNetwork": {
+    "type": "Bridge Exploit",
+    "date": "2026-07-02",
+    "rootCause": "Aztec Network Private Rollup Bridge exploiter-labeled address deposited total of 200 ETH (~$314K equivalent) into Tornado Cash for fund mixing. Exploit confirmed via on-chain tracking of exploiter addresses.\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2072489141573693603](https://twitter.com/PeckShieldAlert/status/2072489141573693603)",
+    "images": [],
+    "Lost": "200.00 ETH",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-02.

Added **3** new incident(s): EdelFinance, Taiko, AztecNetwork

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| EdelFinance | Ethereum | Collateral Price Manipulation | 353000 USD |
| Taiko | Taiko | Unknown | 180 ETH |
| AztecNetwork | Aztec | Bridge Exploit | 200 ETH |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
