### PR TITLE
feat: add Discord-sourced incidents 2026-07-08

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "20260707",
+    "name": "AtlantisLoan",
+    "type": "Smart Contract Vulnerability",
+    "Lost": 931000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260707",
+    "name": "BonkDAO",
+    "type": "Governance Attack",
+    "Lost": 21300000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Solana"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -27,12 +45,48 @@
     "chain": "Aztec"
   },
   {
+    "date": "20260701",
+    "name": "edel-xstock",
+    "type": "Price Oracle Manipulation",
+    "Lost": 204215.57,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260629",
     "name": "AIDC",
     "type": "Smart Contract Logic Flaw",
     "Lost": 220.12,
     "lossType": "WBNB",
     "Contract": "",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260629",
+    "name": "Vault4626",
+    "type": "Business Logic Flaw",
+    "Lost": 13.53,
+    "lossType": "WETH",
+    "Contract": "src/test/2026-06/Vault4626_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260628",
+    "name": "AIDC",
+    "type": "Business Logic Flaw",
+    "Lost": 220.13,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AIDC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260627",
+    "name": "CookFinanceIssuance",
+    "type": "Price Oracle Manipulation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
     "chain": "BSC"
   },
   {
@@ -7873,41 +7927,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260701",
-    "name": "edel-xstock",
-    "type": "Price Oracle Manipulation",
-    "Lost": 204215.57,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260629",
-    "name": "Vault4626",
-    "type": "Business Logic Flaw",
-    "Lost": 13.53,
-    "lossType": "WETH",
-    "Contract": "src/test/2026-06/Vault4626_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260628",
-    "name": "AIDC",
-    "type": "Business Logic Flaw",
-    "Lost": 220.13,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AIDC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260627",
-    "name": "CookFinanceIssuance",
-    "type": "Price Oracle Manipulation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6307,5 +6307,21 @@
     "images": [],
     "Lost": "200.00 ETH",
     "Contract": ""
+  },
+  "AtlantisLoan": {
+    "type": "Smart Contract Vulnerability",
+    "date": "2026-07-07",
+    "rootCause": "Attacker exploited a flaw in Atlantis Loan's smart contract code and drained $931K via attack transaction\n\n**Attack Tx:** [https://etherscan.io/tx/0x0cf758688f0f50df70b439eed3e743add93fb3b1f6a0c1328f116646ee5255be](https://etherscan.io/tx/0x0cf758688f0f50df70b439eed3e743add93fb3b1f6a0c1328f116646ee5255be)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2074125598016913504](https://twitter.com/DefimonAlerts/status/2074125598016913504)",
+    "images": [],
+    "Lost": "$931.0K",
+    "Contract": ""
+  },
+  "BonkDAO": {
+    "type": "Governance Attack",
+    "date": "2026-07-07",
+    "rootCause": "Malicious governance proposal drained 4.426 trillion BONK tokens (~$21.3M at transfer time) from treasury. Proposal stayed live for 6 days without intervention. Stolen tokens sent to 9bxWkNf3BtJ6iehq9KbX9uCWMjem4TFiPZ19T2sYJHvQ; ~$148K moved to OKX.\n\n**Attack Tx:** [https://v2.realms.today/dao/84pGFuy1Y27ApK67ApethaPvexeDWA66zNV8gm38TVeQ/proposal/6wR1jdhhJ31bbdRNXva8MxqsgsNLKTxargcdAyZ7FcRj](https://v2.realms.today/dao/84pGFuy1Y27ApK67ApethaPvexeDWA66zNV8gm38TVeQ/proposal/6wR1jdhhJ31bbdRNXva8MxqsgsNLKTxargcdAyZ7FcRj)\n\n**Source:** [https://twitter.com/CertiKAlert/status/2074295582131449903](https://twitter.com/CertiKAlert/status/2074295582131449903)",
+    "images": [],
+    "Lost": "$21.30M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-08.

Added **2** new incident(s): AtlantisLoan, BonkDAO

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| AtlantisLoan | Ethereum | Smart Contract Vulnerability | 931000 USD |
| BonkDAO | Solana | Governance Attack | 21300000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
