### PR TITLE
feat: add Discord-sourced incidents 2026-07-10

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "20260709",
+    "name": "Hinkal",
+    "type": "Double-Spend / Circuit Binding Gap",
+    "Lost": 800000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260708",
+    "name": "BFB",
+    "type": "Flash Loan + Logic Error",
+    "Lost": 198000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -27,12 +45,48 @@
     "chain": "Aztec"
   },
   {
+    "date": "20260701",
+    "name": "edel-xstock",
+    "type": "Price Oracle Manipulation",
+    "Lost": 204215.57,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260629",
     "name": "AIDC",
     "type": "Smart Contract Logic Flaw",
     "Lost": 220.12,
     "lossType": "WBNB",
     "Contract": "",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260629",
+    "name": "Vault4626",
+    "type": "Business Logic Flaw",
+    "Lost": 13.53,
+    "lossType": "WETH",
+    "Contract": "src/test/2026-06/Vault4626_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260628",
+    "name": "AIDC",
+    "type": "Business Logic Flaw",
+    "Lost": 220.13,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AIDC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260627",
+    "name": "CookFinanceIssuance",
+    "type": "Price Oracle Manipulation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
     "chain": "BSC"
   },
   {
@@ -7873,41 +7927,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260701",
-    "name": "edel-xstock",
-    "type": "Price Oracle Manipulation",
-    "Lost": 204215.57,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260629",
-    "name": "Vault4626",
-    "type": "Business Logic Flaw",
-    "Lost": 13.53,
-    "lossType": "WETH",
-    "Contract": "src/test/2026-06/Vault4626_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260628",
-    "name": "AIDC",
-    "type": "Business Logic Flaw",
-    "Lost": 220.13,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AIDC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260627",
-    "name": "CookFinanceIssuance",
-    "type": "Price Oracle Manipulation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6307,5 +6307,21 @@
     "images": [],
     "Lost": "200.00 ETH",
     "Contract": ""
+  },
+  "BFB": {
+    "type": "Flash Loan + Logic Error",
+    "date": "2026-07-08",
+    "rootCause": "Flash loan exploit targeting deflationary reserve-burn logic in `_priceDeflPool()` (Contract.sol:448). Function burns 5% of LP pair's BFB and calls sync() when price drops >5% below fallLastPrice. Guard only required EOA checks, allowing attacker to trigger repeatedly with zero-value self-transfers across 151 rounds. Collapsed BFB/WBNB pair reserve toward zero, enabling dust BFB swaps for entire WBNB reserve (~350.6 WBNB).\n\n**Attack Tx:** [https://bscscan.com/tx/0xabcf5c5c846595b2d0849f2579b67465ed8d06f3b469cee5e3a57c1f7aed3520](https://bscscan.com/tx/0xabcf5c5c846595b2d0849f2579b67465ed8d06f3b469cee5e3a57c1f7aed3520)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2075080496573284853](https://twitter.com/DefimonAlerts/status/2075080496573284853)",
+    "images": [],
+    "Lost": "$198.0K",
+    "Contract": ""
+  },
+  "Hinkal": {
+    "type": "Double-Spend / Circuit Binding Gap",
+    "date": "2026-07-09",
+    "rootCause": "Double-spend attack on shielded pool via legacy note format flaw. Attacker derived multiple nullifiers from single deposit, circumventing withdrawal restrictions. Circuit-level binding gap failed to bind nullifier uniquely to original note, enabling repeated withdrawals.\n\n**Source:** [https://twitter.com/Phalcon_xyz/status/2075140868886155637](https://twitter.com/Phalcon_xyz/status/2075140868886155637)",
+    "images": [],
+    "Lost": "$800.0K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-10.

Added **2** new incident(s): BFB, Hinkal

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| BFB | BNB Chain | Flash Loan + Logic Error | 198000 USD |
| Hinkal | Ethereum | Double-Spend / Circuit Binding Gap | 800000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
