### PR TITLE
feat: add Discord-sourced incidents 2026-07-12

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260711",
+    "name": "Hedera",
+    "type": "Protocol Exploitation",
+    "Lost": 5250000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Hedera"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -27,12 +36,48 @@
     "chain": "Aztec"
   },
   {
+    "date": "20260701",
+    "name": "edel-xstock",
+    "type": "Price Oracle Manipulation",
+    "Lost": 204215.57,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260629",
     "name": "AIDC",
     "type": "Smart Contract Logic Flaw",
     "Lost": 220.12,
     "lossType": "WBNB",
     "Contract": "",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260629",
+    "name": "Vault4626",
+    "type": "Business Logic Flaw",
+    "Lost": 13.53,
+    "lossType": "WETH",
+    "Contract": "src/test/2026-06/Vault4626_exp.sol",
+    "chain": "Base"
+  },
+  {
+    "date": "20260628",
+    "name": "AIDC",
+    "type": "Business Logic Flaw",
+    "Lost": 220.13,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AIDC_exp.sol",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260627",
+    "name": "CookFinanceIssuance",
+    "type": "Price Oracle Manipulation",
+    "Lost": 50000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
     "chain": "BSC"
   },
   {
@@ -7873,41 +7918,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260701",
-    "name": "edel-xstock",
-    "type": "Price Oracle Manipulation",
-    "Lost": 204215.57,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-07/edel-xstock_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260629",
-    "name": "Vault4626",
-    "type": "Business Logic Flaw",
-    "Lost": 13.53,
-    "lossType": "WETH",
-    "Contract": "src/test/2026-06/Vault4626_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260628",
-    "name": "AIDC",
-    "type": "Business Logic Flaw",
-    "Lost": 220.13,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AIDC_exp.sol",
-    "chain": "BSC"
-  },
-  {
-    "date": "20260627",
-    "name": "CookFinanceIssuance",
-    "type": "Price Oracle Manipulation",
-    "Lost": 50000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-06/CookFinanceIssuance_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6307,5 +6307,13 @@
     "images": [],
     "Lost": "200.00 ETH",
     "Contract": ""
+  },
+  "Hedera": {
+    "type": "Protocol Exploitation",
+    "date": "2026-07-11",
+    "rootCause": "Hedera Network was exploited with $5.25M in stolen funds bridged from Hedera Mainnet to Ethereum. Attacker holds 2.36K ETH ($4.25M) and 15.58 WBTC ($1M). Initial funding from TornadoCash (1 ETH).\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2075867053408629179](https://twitter.com/PeckShieldAlert/status/2075867053408629179)",
+    "images": [],
+    "Lost": "$5.25M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-12.

Added **1** new incident(s): Hedera

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Hedera | Hedera | Protocol Exploitation | 5250000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
