### PR TITLE
feat: add Discord-sourced incidents 2026-07-20

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260719",
+    "name": "RWT",
+    "type": "Flash Loan",
+    "Lost": 118000.0,
+    "lossType": "USDT",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
     "date": "20260715",
     "name": "Drips",
     "type": "Integer Overflow",
@@ -117,6 +126,15 @@
     "chain": "Ethereum"
   },
   {
+    "date": "20260706",
+    "name": "SummerFi",
+    "type": "FleetCommander NAV Inflation via Depegged xUSD",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-07/SummerFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -223,6 +241,15 @@
     "lossType": "USDC",
     "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
     "chain": "Polygon"
+  },
+  {
+    "date": "20260622",
+    "name": "Aztec Escape Hatch",
+    "type": "proof_id Accounting Bypass (whitehat reproduction)",
+    "Lost": 1603.99,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
+    "chain": "Ethereum"
   },
   {
     "date": "20260620",
@@ -8025,24 +8052,6 @@
     "Lost": 514000.0,
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260706",
-    "name": "SummerFi",
-    "type": "FleetCommander NAV Inflation via Depegged xUSD",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-07/SummerFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260622",
-    "name": "Aztec Escape Hatch",
-    "type": "proof_id Accounting Bypass (whitehat reproduction)",
-    "Lost": 1603.99,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
     "chain": "Ethereum"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6411,5 +6411,13 @@
     "images": [],
     "Lost": "$21.2K",
     "Contract": ""
+  },
+  "RWT": {
+    "type": "Flash Loan",
+    "date": "2026-07-19",
+    "rootCause": "Unprotected sell() contract in RWT token allowed burning tokens directly from the RWT/USDT PancakePair reserves. The sell contract holds the onlyOwner role on RWT.burn(), enabling it to collapse the pair's RWT reserve and artificially inflate RWT's price in USDT. Attacker flash-loaned 1M USDT and executed the exploit 18 times in a single transaction, extracting USDT at manipulated prices. Total drained: ~158.6K USDT and ~110M RWT from the pair.\n\n**Attack Tx:** [https://bscscan.com/tx/0x22300140e7c44899c2602382a6e7a4a34a70f47f9736721744bc6434c07171dc](https://bscscan.com/tx/0x22300140e7c44899c2602382a6e7a4a34a70f47f9736721744bc6434c07171dc)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2078826324320248147](https://twitter.com/DefimonAlerts/status/2078826324320248147)",
+    "images": [],
+    "Lost": "$118.0K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-20.

Added **1** new incident(s): RWT

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| RWT | BNB Chain | Flash Loan | 118000 USDT |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
