### PR TITLE
feat: add Discord-sourced incidents 2026-07-23

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "20260722",
+    "name": "42DAO",
+    "type": "Oracle Manipulation",
+    "Lost": 912000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BSC"
+  },
+  {
+    "date": "20260722",
+    "name": "BSquaredNetwork",
+    "type": "Token Drain",
+    "Lost": 8591000.0,
+    "lossType": "B2",
+    "Contract": "",
+    "chain": "BSC"
+  },
+  {
     "date": "20260719",
     "name": "RWT",
     "type": "Flash Loan",
@@ -7,6 +25,15 @@
     "lossType": "USDT",
     "Contract": "",
     "chain": "BNB Chain"
+  },
+  {
+    "date": "20260719",
+    "name": "RWT Token",
+    "type": "Deflationary burn-from-pair price manipulation",
+    "Lost": 118000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-07/RWT_exp.sol",
+    "chain": "BSC"
   },
   {
     "date": "20260715",
@@ -135,6 +162,15 @@
     "chain": "Ethereum"
   },
   {
+    "date": "20260706",
+    "name": "SummerFi",
+    "type": "FleetCommander NAV Inflation via Depegged xUSD",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-07/SummerFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -241,6 +277,15 @@
     "lossType": "USDC",
     "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
     "chain": "Polygon"
+  },
+  {
+    "date": "20260622",
+    "name": "Aztec Escape Hatch",
+    "type": "proof_id Accounting Bypass (whitehat reproduction)",
+    "Lost": 1603.99,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
+    "chain": "Ethereum"
   },
   {
     "date": "20260622",
@@ -8053,32 +8098,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260706",
-    "name": "SummerFi",
-    "type": "FleetCommander NAV Inflation via Depegged xUSD",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-07/SummerFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260622",
-    "name": "Aztec Escape Hatch",
-    "type": "proof_id Accounting Bypass (whitehat reproduction)",
-    "Lost": 1603.99,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260719",
-    "name": "RWT Token",
-    "type": "Deflationary burn-from-pair price manipulation",
-    "Lost": 118000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-07/RWT_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6419,5 +6419,21 @@
     "images": [],
     "Lost": "$118.0K",
     "Contract": ""
+  },
+  "42DAO": {
+    "type": "Oracle Manipulation",
+    "date": "2026-07-22",
+    "rootCause": "Single-signer oracle vulnerability (bar=1 threshold). Attacker used authorized signer key to push BTCB price to 10^20 via Spotter.poke(). Price propagated through Dog liquidation module without validation, enabling liquidation of BTCB vaults at inflated collateral value. Attacker withdrew 10.737 BTCB with only 0.006284 BTCB collateral backing, borrowed 4.5M BLC tokens, and swapped for ~761,696 USDT. Follow-up attack pushed price down and liquidated additional positions for ~$122K profit.\n\n**Attack Tx:** [https://bscscan.com/tx/0xe54b7123fb6f5bb8c259febcce5b9e312a8c0d100e2fe82c3cb44488c626cbaf](https://bscscan.com/tx/0xe54b7123fb6f5bb8c259febcce5b9e312a8c0d100e2fe82c3cb44488c626cbaf)\n\n**Source:** [https://twitter.com/SlowMist_Team/status/2079759793192132810](https://twitter.com/SlowMist_Team/status/2079759793192132810)",
+    "images": [],
+    "Lost": "$912.0K",
+    "Contract": ""
+  },
+  "BSquaredNetwork": {
+    "type": "Token Drain",
+    "date": "2026-07-22",
+    "rootCause": "Draining of 8.591M B2 tokens. Team estimated USD loss at approximately $3.86M USD (based on ransom demand: 10% of stolen funds = ~$386K USD).\n\n**Attack Tx:** [https://bscscan.com/tx/0x29d3031a1d331cffdb1607153be9ee20adcad8c55d51bc32fc96c6f358cf5ea2](https://bscscan.com/tx/0x29d3031a1d331cffdb1607153be9ee20adcad8c55d51bc32fc96c6f358cf5ea2)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2080060105433682085](https://twitter.com/DefimonAlerts/status/2080060105433682085)",
+    "images": [],
+    "Lost": "8591000.00 B2",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-23.

Added **2** new incident(s): 42DAO, BSquaredNetwork

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| 42DAO | BSC | Oracle Manipulation | 912000 USD |
| BSquaredNetwork | BSC | Token Drain | 8591000 B2 |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
