### PR TITLE
feat: add Discord-sourced incidents 2026-07-24

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,32 @@
 [
   {
+    "date": "20260723",
+    "name": "BSquaredNetwork",
+    "type": "Exploit",
+    "Lost": 3860000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
+    "date": "20260723",
+    "name": "VerusCoin",
+    "type": "Key Compromise",
+    "Lost": 7330000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260722",
+    "name": "AFX",
+    "type": "Key Compromise",
+    "Lost": 24150000.0,
+    "lossType": "USDC",
+    "Contract": "",
+    "chain": "Arbitrum"
+  },
+  {
     "date": "20260719",
     "name": "RWT",
     "type": "Flash Loan",
@@ -7,6 +34,15 @@
     "lossType": "USDT",
     "Contract": "",
     "chain": "BNB Chain"
+  },
+  {
+    "date": "20260719",
+    "name": "RWT Token",
+    "type": "Deflationary burn-from-pair price manipulation",
+    "Lost": 118000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-07/RWT_exp.sol",
+    "chain": "BSC"
   },
   {
     "date": "20260715",
@@ -135,6 +171,15 @@
     "chain": "Ethereum"
   },
   {
+    "date": "20260706",
+    "name": "SummerFi",
+    "type": "FleetCommander NAV Inflation via Depegged xUSD",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-07/SummerFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -241,6 +286,15 @@
     "lossType": "USDC",
     "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
     "chain": "Polygon"
+  },
+  {
+    "date": "20260622",
+    "name": "Aztec Escape Hatch",
+    "type": "proof_id Accounting Bypass (whitehat reproduction)",
+    "Lost": 1603.99,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
+    "chain": "Ethereum"
   },
   {
     "date": "20260622",
@@ -8053,32 +8107,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260706",
-    "name": "SummerFi",
-    "type": "FleetCommander NAV Inflation via Depegged xUSD",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-07/SummerFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260622",
-    "name": "Aztec Escape Hatch",
-    "type": "proof_id Accounting Bypass (whitehat reproduction)",
-    "Lost": 1603.99,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260719",
-    "name": "RWT Token",
-    "type": "Deflationary burn-from-pair price manipulation",
-    "Lost": 118000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-07/RWT_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6419,5 +6419,29 @@
     "images": [],
     "Lost": "$118.0K",
     "Contract": ""
+  },
+  "BSquaredNetwork": {
+    "type": "Exploit",
+    "date": "2026-07-23",
+    "rootCause": "8.591M $B2 tokens drained from protocol; specific exploit mechanism not disclosed. Attacker swapped stolen tokens to 1,128 ETH via WBNB intermediate and bridged out via NEAR Intents. Token price declined -15%.\n\n**Attack Tx:** [https://bscscan.com/tx/0x29d3031a1d331cffdb1607153be9ee20adcad8c55d51bc32fc96c6f358cf5ea2](https://bscscan.com/tx/0x29d3031a1d331cffdb1607153be9ee20adcad8c55d51bc32fc96c6f358cf5ea2)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2080060105433682085](https://twitter.com/DefimonAlerts/status/2080060105433682085)",
+    "images": [],
+    "Lost": "$3.86M",
+    "Contract": ""
+  },
+  "AFX": {
+    "type": "Key Compromise",
+    "date": "2026-07-22",
+    "rootCause": "5 of 7 bridge validator keys compromised, carrying 7,142/10,000 total power (exceeds 2/3 quorum). Two-phase attack: (1) Propose transaction with 5 compromised validator signatures, (2) Execute after 200-second dispute window to release 24.15M USDC via CCTP bridge to Ethereum. Stolen funds converted to 12,467.43 ETH at 0x627654B2782bfC57580ecD11d40869b350B6ebAC.\n\n**Attack Tx:** [https://arbiscan.io/tx/0x50d0b3ec6c3f5fce0f10abf81540bbb508f421494aa2b3480c4a264b0436547b](https://arbiscan.io/tx/0x50d0b3ec6c3f5fce0f10abf81540bbb508f421494aa2b3480c4a264b0436547b)\n\n**Source:** [https://twitter.com/1nf0s3cpt/status/2080082521778467217](https://twitter.com/1nf0s3cpt/status/2080082521778467217)",
+    "images": [],
+    "Lost": "$24.15M",
+    "Contract": ""
+  },
+  "VerusCoin": {
+    "type": "Key Compromise",
+    "date": "2026-07-23",
+    "rootCause": "Verus-Ethereum bridge exploited via 11-of-15 compromised Notary keys and missing economic validation on cross-chain imports. Attacker crafted malicious Verus-side import with unbacked payout request. Bridge verified notary signatures and Merkle proofs but failed to confirm payout amounts matched Verus-side backing. Released ~1.14K ETH, 71.5 tBTC, 59.4 MKR, plus USDC/USDT/DAI/EUROC/scrvUSD (~$7.33M total). Stolen ETH (3,916.1 ETH) laundered through Tornado Cash.\n\n**Attack Tx:** [https://etherscan.io/tx/0xa1f1e65c1cea4dba4ae439cd4dcdba6cc2dbda0ed1228e61f29ae9c9324eb099](https://etherscan.io/tx/0xa1f1e65c1cea4dba4ae439cd4dcdba6cc2dbda0ed1228e61f29ae9c9324eb099)\n\n**Source:** [https://twitter.com/1nf0s3cpt/status/2080162610444677132](https://twitter.com/1nf0s3cpt/status/2080162610444677132)",
+    "images": [],
+    "Lost": "$7.33M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-24.

Added **3** new incident(s): BSquaredNetwork, AFX, VerusCoin

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| BSquaredNetwork | BNB Chain | Exploit | 3860000 USD |
| AFX | Arbitrum | Key Compromise | 24150000 USDC |
| VerusCoin | Ethereum | Key Compromise | 7330000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
