### PR TITLE
feat: add Discord-sourced incidents 2026-07-25

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "20260724",
+    "name": "LienFinance",
+    "type": "Access Control / Bond Minting Flaw",
+    "Lost": 542144.0,
+    "lossType": "USDC",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260723",
+    "name": "VerusCoin",
+    "type": "Bridge Exploit (Notary Compromise)",
+    "Lost": 7330000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260719",
     "name": "RWT",
     "type": "Flash Loan",
@@ -7,6 +25,15 @@
     "lossType": "USDT",
     "Contract": "",
     "chain": "BNB Chain"
+  },
+  {
+    "date": "20260719",
+    "name": "RWT Token",
+    "type": "Deflationary burn-from-pair price manipulation",
+    "Lost": 118000.0,
+    "lossType": "USDT",
+    "Contract": "src/test/2026-07/RWT_exp.sol",
+    "chain": "BSC"
   },
   {
     "date": "20260715",
@@ -135,6 +162,15 @@
     "chain": "Ethereum"
   },
   {
+    "date": "20260706",
+    "name": "SummerFi",
+    "type": "FleetCommander NAV Inflation via Depegged xUSD",
+    "Lost": 6000000.0,
+    "lossType": "USD",
+    "Contract": "src/test/2026-07/SummerFi_exp.sol",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260702",
     "name": "EdelFinance",
     "type": "Collateral Price Manipulation",
@@ -241,6 +277,15 @@
     "lossType": "USDC",
     "Contract": "src/test/2026-06/RoyalRoyalties_exp.sol",
     "chain": "Polygon"
+  },
+  {
+    "date": "20260622",
+    "name": "Aztec Escape Hatch",
+    "type": "proof_id Accounting Bypass (whitehat reproduction)",
+    "Lost": 1603.99,
+    "lossType": "WBNB",
+    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
+    "chain": "Ethereum"
   },
   {
     "date": "20260622",
@@ -907,6 +952,15 @@
     "lossType": "USD",
     "Contract": "",
     "chain": "59144"
+  },
+  {
+    "date": "20260401",
+    "name": "Drift",
+    "type": "Smart Contract Exploit",
+    "Lost": 285000000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Solana"
   },
   {
     "date": "20260331",
@@ -8053,32 +8107,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260706",
-    "name": "SummerFi",
-    "type": "FleetCommander NAV Inflation via Depegged xUSD",
-    "Lost": 6000000.0,
-    "lossType": "USD",
-    "Contract": "src/test/2026-07/SummerFi_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260622",
-    "name": "Aztec Escape Hatch",
-    "type": "proof_id Accounting Bypass (whitehat reproduction)",
-    "Lost": 1603.99,
-    "lossType": "WBNB",
-    "Contract": "src/test/2026-06/AztecEscapeHatch_exp2.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260719",
-    "name": "RWT Token",
-    "type": "Deflationary burn-from-pair price manipulation",
-    "Lost": 118000.0,
-    "lossType": "USDT",
-    "Contract": "src/test/2026-07/RWT_exp.sol",
-    "chain": "BSC"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6419,5 +6419,29 @@
     "images": [],
     "Lost": "$118.0K",
     "Contract": ""
+  },
+  "VerusCoin": {
+    "type": "Bridge Exploit (Notary Compromise)",
+    "date": "2026-07-23",
+    "rootCause": "Verus<>Ethereum bridge drained via 11-of-15 Notaries with compromised private keys used to authorize malicious state root; attacker submitted crafted cross-chain proofs with abnormally shallow Merkle paths (3 segments vs 17 legitimate) through submitImports() to release ~1.14K ETH, 71.5 tBTC, 59.4 MKR, USDC/USDT/DAI/EUROC/scrvUSD from bridge reserves; code lacked proof-depth validation and branchType enforcement.\n\n**Attack Tx:** [https://etherscan.io/tx/0xa1f1e65c1cea4dba4ae439cd4dcdba6cc2dbda0ed1228e61f29ae9c9324eb099](https://etherscan.io/tx/0xa1f1e65c1cea4dba4ae439cd4dcdba6cc2dbda0ed1228e61f29ae9c9324eb099)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2080271385713066152](https://twitter.com/DefimonAlerts/status/2080271385713066152)",
+    "images": [],
+    "Lost": "$7.33M",
+    "Contract": ""
+  },
+  "Drift": {
+    "type": "Smart Contract Exploit",
+    "date": "2026-04-01",
+    "rootCause": "Drift protocol suffered exploit April 1, 2026 resulting in ~$285M loss; exploiter-labeled address subsequently deposited 23,095.1 ETH (~$44.4M) into TornadoCash for laundering.\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2080509354638508420](https://twitter.com/PeckShieldAlert/status/2080509354638508420)",
+    "images": [],
+    "Lost": "$285.00M",
+    "Contract": ""
+  },
+  "LienFinance": {
+    "type": "Access Control / Bond Minting Flaw",
+    "date": "2026-07-24",
+    "rootCause": "GeneralizedDotc OTC pools drained via permissionless bond group registration and flawed multiset integrity in BondMakerCollateralizedEth.exchangeEquivalentBonds(); attacker-deployed contract minted unbacked bonds with crafted payoff functions, repeated exception bondIDs to mask missing inputs, swapped worthless bonds for USDC via three pre-authorized liquidity pools; _calcRateBondToErc20 oracle inflated bond valuations.\n\n**Attack Tx:** [https://etherscan.io/tx/0xb96d572b557a12f5ef193e88cca86123a6ae1b6e98b0eeee265870c85848e0e7](https://etherscan.io/tx/0xb96d572b557a12f5ef193e88cca86123a6ae1b6e98b0eeee265870c85848e0e7)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2080531008365920472](https://twitter.com/DefimonAlerts/status/2080531008365920472)",
+    "images": [],
+    "Lost": "$542.1K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-25.

Added **3** new incident(s): VerusCoin, Drift, LienFinance

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| VerusCoin | Ethereum | Bridge Exploit (Notary Compromise) | 7330000 USD |
| Drift | Solana | Smart Contract Exploit | 285000000 USD |
| LienFinance | Ethereum | Access Control / Bond Minting Flaw | 542144 USDC |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
