### PR TITLE
feat: add Discord-sourced incidents 2026-07-28

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,11 +1,29 @@
 [
   {
+    "date": "20260725",
+    "name": "Projekt",
+    "type": "Flash Loan Attack",
+    "Lost": 560000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260724",
     "name": "LienFinance",
     "type": "Access Control / Bond Minting Flaw",
     "Lost": 542144.0,
     "lossType": "USDC",
     "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
+    "date": "20260724",
+    "name": "Lien Finance",
+    "type": "Permissionless bond registration / payoff mispricing",
+    "Lost": 542144.0,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-07/LienFinance_exp.sol",
     "chain": "Ethereum"
   },
   {
@@ -8124,15 +8142,6 @@
     "Lost": 514000.0,
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
-    "chain": "Ethereum"
-  },
-  {
-    "date": "20260724",
-    "name": "Lien Finance",
-    "type": "Permissionless bond registration / payoff mispricing",
-    "Lost": 542144.0,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-07/LienFinance_exp.sol",
     "chain": "Ethereum"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6459,5 +6459,13 @@
     "images": [],
     "Lost": "$542.1K",
     "Contract": ""
+  },
+  "Projekt": {
+    "type": "Flash Loan Attack",
+    "date": "2026-07-25",
+    "rootCause": "A permissionless 'buy-to-earn' reward vault (0x574f...42cb) was exploited via a flash loan attack. The attacker flash-loaned ~14K WETH from Morpho, used it to manipulate token balances across multiple Uniswap V2 memecoin pairs (Kirby Inu, ROTTSCHILD, etc.), and registered huge fake 'purchase' allocations via the unverified trackPurchase() function. The function read the buyer's token balance delta without verifying actual ETH was spent, allowing the attacker to drain ~301.7 ETH (~$560K) from the vault's reward pool via massWithdraw(). The flash loan was repaid in the same transaction.\n\n**Attack Tx:** [https://etherscan.io/tx/0x90f40d3c3b60370f7287d51d972ef54596c46e98f21af91b03a4e84c5e410f64](https://etherscan.io/tx/0x90f40d3c3b60370f7287d51d972ef54596c46e98f21af91b03a4e84c5e410f64)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2081781283584106959](https://twitter.com/DefimonAlerts/status/2081781283584106959)",
+    "images": [],
+    "Lost": "$560.0K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-28.

Added **1** new incident(s): Projekt

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Projekt | Ethereum | Flash Loan Attack | 560000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
