### PR TITLE
feat: add Discord-sourced incidents 2026-07-29

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260728",
+    "name": "Across",
+    "type": "Exploit",
+    "Lost": 3600000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Solana"
+  },
+  {
     "date": "20260725",
     "name": "Projekt",
     "type": "Flash Loan Attack",
@@ -25,6 +34,15 @@
     "lossType": "USDC",
     "Contract": "src/test/2026-07/LienFinance_exp.sol",
     "chain": "Ethereum"
+  },
+  {
+    "date": "20260724",
+    "name": "TripleA",
+    "type": "Hot Wallet Compromise",
+    "Lost": 9700000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Multi-Chain"
   },
   {
     "date": "20260723",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6467,5 +6467,21 @@
     "images": [],
     "Lost": "$560.0K",
     "Contract": ""
+  },
+  "TripleA": {
+    "type": "Hot Wallet Compromise",
+    "date": "2026-07-24",
+    "rootCause": "Hot wallets compromised and drained across five chains (Tron 71%, Ethereum, Arbitrum, Polygon, Solana) via automated sweep lasting ~22 hours starting July 24 at 19:31 UTC. At least $9.7M traced.\n\n**Source:** [https://twitter.com/Phalcon_xyz/status/2082025998774657089](https://twitter.com/Phalcon_xyz/status/2082025998774657089)",
+    "images": [],
+    "Lost": "$9.70M",
+    "Contract": ""
+  },
+  "Across": {
+    "type": "Exploit",
+    "date": "2026-07-28",
+    "rootCause": "Across Protocol attacked on Solana, ~$3.6M worth of cryptos drained. Exploiter's labeled address later refunded 331.8 ETH (~$623.9K) to Across Protocol Hub Pool Owner Multisig.\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2082034098458214567](https://twitter.com/PeckShieldAlert/status/2082034098458214567)",
+    "images": [],
+    "Lost": "$3.60M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-07-29.

Added **2** new incident(s): TripleA, Across

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| TripleA | Multi-Chain | Hot Wallet Compromise | 9700000 USD |
| Across | Solana | Exploit | 3600000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
