### PR TITLE
feat: add Discord-sourced incidents 2026-08-01

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260730",
+    "name": "SwanTreasury",
+    "type": "Private Key Compromise",
+    "Lost": 625000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
     "date": "20260728",
     "name": "Across",
     "type": "Exploit",
@@ -7,6 +16,15 @@
     "lossType": "USD",
     "Contract": "",
     "chain": "Solana"
+  },
+  {
+    "date": "20260726",
+    "name": "ChainConnect",
+    "type": "Bridge Exploit",
+    "Lost": 329.0,
+    "lossType": "ETH",
+    "Contract": "",
+    "chain": "Ethereum"
   },
   {
     "date": "20260725",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6483,5 +6483,21 @@
     "images": [],
     "Lost": "$3.60M",
     "Contract": ""
+  },
+  "SwanTreasury": {
+    "type": "Private Key Compromise",
+    "date": "2026-07-30",
+    "rootCause": "Off-chain signer key (0xdEb4...8284) hardcoded in ZhaiquanBuy contract was compromised. Attacker forged valid signatures to purchase STY at 100x discount (~687K STY for ~19.7K USDT via PancakeSwap flash loan), then dumped tokens for ~$625K USDT profit.\n\n**Attack Tx:** [https://bscscan.com/tx/0xc8c3325ba2c942a674b26de2063d278c144e92dbc91497ca0c766c915d96cbd4](https://bscscan.com/tx/0xc8c3325ba2c942a674b26de2063d278c144e92dbc91497ca0c766c915d96cbd4)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2083039796784410802](https://twitter.com/DefimonAlerts/status/2083039796784410802)",
+    "images": [],
+    "Lost": "$625.0K",
+    "Contract": ""
+  },
+  "ChainConnect": {
+    "type": "Bridge Exploit",
+    "date": "2026-07-26",
+    "rootCause": "ChainConnect bridge exploited on July 26. Attacker held ~329 ETH for ransom; whitehat agreement reached: attacker returned 280 ETH (85% of total stolen) to 0x840B3De19e3FAB72fa9A168bD8Dd71B678c57989 and retained ~49 ETH (15%) as bounty. Recovery confirmed July 31, 2026.\n\n**Attack Tx:** [https://etherscan.io/tx/0xa6df21e27c5228af87e35122b506751c642fe012b2f61c84e046625718d0c85b](https://etherscan.io/tx/0xa6df21e27c5228af87e35122b506751c642fe012b2f61c84e046625718d0c85b)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2083213179333534148](https://twitter.com/DefimonAlerts/status/2083213179333534148)",
+    "images": [],
+    "Lost": "329.00 ETH",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-01.

Added **2** new incident(s): SwanTreasury, ChainConnect

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| SwanTreasury | BNB Chain | Private Key Compromise | 625000 USD |
| ChainConnect | Ethereum | Bridge Exploit | 329 ETH |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
