### PR TITLE
feat: add Discord-sourced incidents 2026-08-04

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260802",
+    "name": "LpdFi",
+    "type": "Flash Loan / Price Manipulation",
+    "Lost": 693500.0,
+    "lossType": "USDC",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
     "date": "20260730",
     "name": "SwanTreasury",
     "type": "Private Key Compromise",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6499,5 +6499,13 @@
     "images": [],
     "Lost": "329.00 ETH",
     "Contract": ""
+  },
+  "LpdFi": {
+    "type": "Flash Loan / Price Manipulation",
+    "date": "2026-08-02",
+    "rootCause": "Oracle vulnerability: LpdFi's price() function relied directly on PancakeSwap LPD/USDC pair spot reserves without TWAP protection. Attacker flash-borrowed USDC, manipulated reserves via donate+sync, inflated interest calculations, then claimed interest via removeLp() to drain the protocol's ~1.68M LP position. ~693.5K USDC extracted in single transaction.\n\n**Attack Tx:** [https://bscscan.com/tx/0x70bbe0aa3c7ef149ecb6128a06025885deaa8fef3f393a505d447d28ab3315d6](https://bscscan.com/tx/0x70bbe0aa3c7ef149ecb6128a06025885deaa8fef3f393a505d447d28ab3315d6)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2084157533204197380](https://twitter.com/DefimonAlerts/status/2084157533204197380)",
+    "images": [],
+    "Lost": "$693.5K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-04.

Added **1** new incident(s): LpdFi

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| LpdFi | BNB Chain | Flash Loan / Price Manipulation | 693500 USDC |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
