### PR TITLE
feat: add Discord-sourced incidents 2026-08-07

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -18,6 +18,24 @@
     "chain": "Base"
   },
   {
+    "date": "20260806",
+    "name": "LULA",
+    "type": "Reserve Manipulation",
+    "Lost": 578000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
+    "date": "20260806",
+    "name": "Strongblock",
+    "type": "Governance Takeover",
+    "Lost": 72000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260804",
     "name": "Nereus",
     "type": "Proxy Upgrade Attack",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6531,5 +6531,21 @@
     "images": [],
     "Lost": "$136.0K",
     "Contract": ""
+  },
+  "LULA": {
+    "type": "Reserve Manipulation",
+    "date": "2026-08-06",
+    "rootCause": "BNB Chain reserve manipulation attack resulting in approximately $578K loss. Detailed technical analysis available in BlockSec's weekly Web3 security roundup.\n\n**Source:** [https://twitter.com/Phalcon_xyz/status/2085194687783313852](https://twitter.com/Phalcon_xyz/status/2085194687783313852)",
+    "images": [],
+    "Lost": "$578.0K",
+    "Contract": ""
+  },
+  "Strongblock": {
+    "type": "Governance Takeover",
+    "date": "2026-08-06",
+    "rootCause": "Attacker exploited abandoned on-chain Governor contract. Holding majority STRONG vote tokens, attacker executed governance proposal calling setPendingAdmin(attacker), then upgraded proxy to malicious unverified implementation with arbitrary-call backdoor. Drained 32,695 STRONG + 383,447 STRNGR tokens ($72K). Attacker: 0xacbca357981870f30130b145762d671891ca810c. Victim: 0xBDDC7Ef8BaCeacE16DCE005102639a4bB86CB8C1.\n\n**Attack Tx:** [https://etherscan.io/tx/0x92be5e374e260192f8fdb5ffdc33504c768ecad091cc7dbc37282e5ca8ea94c6](https://etherscan.io/tx/0x92be5e374e260192f8fdb5ffdc33504c768ecad091cc7dbc37282e5ca8ea94c6)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2085246380231004319](https://twitter.com/DefimonAlerts/status/2085246380231004319)",
+    "images": [],
+    "Lost": "$72.0K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-07.

Added **2** new incident(s): LULA, Strongblock

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| LULA | BNB Chain | Reserve Manipulation | 578000 USD |
| Strongblock | Ethereum | Governance Takeover | 72000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
