### PR TITLE
feat: add Discord-sourced incidents 2026-08-08

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260807",
+    "name": "ZKPanther",
+    "type": "Governance Attack",
+    "Lost": 5120000.0,
+    "lossType": "ZKP",
+    "Contract": "",
+    "chain": "Base"
+  },
+  {
     "date": "20260804",
     "name": "Nereus",
     "type": "Proxy Upgrade Attack",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6515,5 +6515,13 @@
     "images": [],
     "Lost": "$23.8K",
     "Contract": ""
+  },
+  "ZKPanther": {
+    "type": "Governance Attack",
+    "date": "2026-08-07",
+    "rootCause": "Attacker submitted a governance proposal named 'zkp-reexploit' to upgrade each ZKP proxy to a drainer implementation. The attacker posted a 'yes' answer with 0.5 ETH bond. No honest party counter-bonded within the 12h timeout + 8h cooldown. The answer finalized and governance module executed the drain.\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2085673531409400047](https://twitter.com/DefimonAlerts/status/2085673531409400047)",
+    "images": [],
+    "Lost": "5120000.00 ZKP",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-08.

Added **1** new incident(s): ZKPanther

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| ZKPanther | Base | Governance Attack | 5120000 ZKP |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
