### PR TITLE
feat: add Discord-sourced incidents 2026-08-20

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260819",
+    "name": "MayaProtocol",
+    "type": "Accounting Manipulation",
+    "Lost": 1700000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Maya"
+  },
+  {
     "date": "20260809",
     "name": "USM",
     "type": "Flash Loan + Pricing Logic Flaw",
@@ -16,6 +25,15 @@
     "lossType": "ZKP",
     "Contract": "",
     "chain": "Base"
+  },
+  {
+    "date": "20260807",
+    "name": "Atomic",
+    "type": "Flash-loan price oracle manipulation of lending collateral valuation",
+    "Lost": 29984.27,
+    "lossType": "USDC",
+    "Contract": "src/test/2026-08/Atomic_exp.sol",
+    "chain": "Unknown"
   },
   {
     "date": "20260806",
@@ -61,6 +79,15 @@
     "lossType": "USD",
     "Contract": "",
     "chain": "BNB Chain"
+  },
+  {
+    "date": "20260730",
+    "name": "UnprotectedArbBot",
+    "type": "Unprotected arbitrary-call forwarder drained via pre-granted WETH allowance",
+    "Lost": 16.623,
+    "lossType": "WETH",
+    "Contract": "src/test/2026-07/UnprotectedArbBot_exp.sol",
+    "chain": "Base"
   },
   {
     "date": "20260728",
@@ -8233,23 +8260,5 @@
     "lossType": "ETH",
     "Contract": "src/test/2017-11/Parity_kill_exp.sol",
     "chain": "Ethereum"
-  },
-  {
-    "date": "20260730",
-    "name": "UnprotectedArbBot",
-    "type": "Unprotected arbitrary-call forwarder drained via pre-granted WETH allowance",
-    "Lost": 16.623,
-    "lossType": "WETH",
-    "Contract": "src/test/2026-07/UnprotectedArbBot_exp.sol",
-    "chain": "Base"
-  },
-  {
-    "date": "20260807",
-    "name": "Atomic",
-    "type": "Flash-loan price oracle manipulation of lending collateral valuation",
-    "Lost": 29984.27,
-    "lossType": "USDC",
-    "Contract": "src/test/2026-08/Atomic_exp.sol",
-    "chain": "Unknown"
   }
 ]

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6547,5 +6547,13 @@
     "images": [],
     "Lost": "$72.0K",
     "Contract": ""
+  },
+  "MayaProtocol": {
+    "type": "Accounting Manipulation",
+    "date": "2026-08-19",
+    "rootCause": "Attacker inflated ARB.LINK accounting with false subsidy, then executed add/remove liquidity operations to extract ~48.87M CACAO and 98.82 LINK from shared liquidity pool. Attacker: maya1dl3yrfpedyr5jfr0r86s2apjltnjqgszmwsv8x\n\n**Attack Tx:** [https://www.explorer.mayachain.info/tx/516BA14D6976EC7B8A3087E1C52B195433EF0F9D85F4B9520675BC4FEB99E9B7](https://www.explorer.mayachain.info/tx/516BA14D6976EC7B8A3087E1C52B195433EF0F9D85F4B9520675BC4FEB99E9B7)\n\n**Source:** [https://twitter.com/CertiKAlert/status/2089900489752318181](https://twitter.com/CertiKAlert/status/2089900489752318181)",
+    "images": [],
+    "Lost": "$1.70M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-20.

Added **1** new incident(s): MayaProtocol

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| MayaProtocol | Maya | Accounting Manipulation | 1700000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
