### PR TITLE
feat: add Discord-sourced incidents 2026-08-23

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260822",
+    "name": "TheSandbox",
+    "type": "Token Minting",
+    "Lost": 14900000000.0,
+    "lossType": "SAND",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260819",
     "name": "MayaProtocol",
     "type": "Accounting Manipulation",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6555,5 +6555,13 @@
     "images": [],
     "Lost": "$1.70M",
     "Contract": ""
+  },
+  "TheSandbox": {
+    "type": "Token Minting",
+    "date": "2026-08-22",
+    "rootCause": "14.9B SAND tokens minted across addresses 0xAbE0...4D22 and 0x638C...F296 through unauthorized access to token minting contract.\n\n**Source:** [https://twitter.com/PeckShieldAlert/status/2091037704314339331](https://twitter.com/PeckShieldAlert/status/2091037704314339331)",
+    "images": [],
+    "Lost": "14900000000.00 SAND",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-23.

Added **1** new incident(s): TheSandbox

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| TheSandbox | Ethereum | Token Minting | 14900000000 SAND |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
