### PR TITLE
feat: add Discord-sourced incidents 2026-08-25

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260824",
+    "name": "Arrakis",
+    "type": "Flash Loan Sandwich",
+    "Lost": 2.94,
+    "lossType": "WETH",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260823",
     "name": "TermFinance",
     "type": "Governance Attack",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6571,5 +6571,13 @@
     "images": [],
     "Lost": "$8.50M",
     "Contract": ""
+  },
+  "Arrakis": {
+    "type": "Flash Loan Sandwich",
+    "date": "2026-08-24",
+    "rootCause": "State-dependent Uniswap V3 vault accounting vulnerable to atomic liquidity sandwich. Attacker minted shares against one pool composition, manipulated price and accrued fees, then burned under changed position state. Lack of same-transaction mint–burn protection. Attacker: 0xa3b096e4df1247794599a37af8f5b8cb05d5eb44; Attack contract: 0x028d9c17b1a097e7e115a6400203df86339baf4a; Flash loan from Morpho.\n\n**Attack Tx:** [https://etherscan.io/tx/0x6ae3af4b2f25a56594de99cfb31369150dd9ac059c49efe04b9e3e0163dbc672](https://etherscan.io/tx/0x6ae3af4b2f25a56594de99cfb31369150dd9ac059c49efe04b9e3e0163dbc672)\n\n**Source:** [https://twitter.com/SlowMist_Team/status/2091738634210996429](https://twitter.com/SlowMist_Team/status/2091738634210996429)",
+    "images": [],
+    "Lost": "2.94 WETH",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-25.

Added **1** new incident(s): Arrakis

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Arrakis | Ethereum | Flash Loan Sandwich | 2.94 WETH |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
