### PR TITLE
feat: add Discord-sourced incidents 2026-08-29

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260827",
+    "name": "CashCowCoin",
+    "type": "Flash Loan",
+    "Lost": 117400.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "BNB Chain"
+  },
+  {
     "date": "20260826",
     "name": "Enjin",
     "type": "Storage Slot Collision",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6603,5 +6603,13 @@
     "images": [],
     "Lost": "$1.76M",
     "Contract": ""
+  },
+  "CashCowCoin": {
+    "type": "Flash Loan",
+    "date": "2026-08-27",
+    "rootCause": "Attacker flash-loaned ~416,831 WBNB from a Moolah lending market, donated WBNB directly into the CCC/WBNB PancakePair, and called sync() to inflate reserves. Then cycled buy/sell against the manipulated price to extract the pair's real liquidity. The pair was drained from ~165.5 WBNB to ~0.018 WBNB (~$117K netted after repaying flash loan).\n\n**Attack Tx:** [https://bscscan.com/tx/0x89d8050641019a5a75fa3dafb4f64fb153e4dd30c0f1f51d06a6cc206d3ead43](https://bscscan.com/tx/0x89d8050641019a5a75fa3dafb4f64fb153e4dd30c0f1f51d06a6cc206d3ead43)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2093248983942467612](https://twitter.com/DefimonAlerts/status/2093248983942467612)",
+    "images": [],
+    "Lost": "$117.4K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-29.

Added **1** new incident(s): CashCowCoin

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| CashCowCoin | BNB Chain | Flash Loan | 117400 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
