### PR TITLE
feat: add Discord-sourced incidents 2026-08-30

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260829",
+    "name": "Avici",
+    "type": "Smart Contract Exploit",
+    "Lost": 1020000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Solana"
+  },
+  {
     "date": "20260827",
     "name": "CashCowCoin",
     "type": "Flash Loan",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6611,5 +6611,13 @@
     "images": [],
     "Lost": "$117.4K",
     "Contract": ""
+  },
+  "Avici": {
+    "type": "Smart Contract Exploit",
+    "date": "2026-08-29",
+    "rootCause": "Attacker transferred 10k SOL, swapped to ~$1.02M USDC, bridged to Ethereum via 0x2cE21E4921d3Eb116526c3651Dac0257657338D5, swapped to ~418 ETH, and deposited to Tornado Cash.\n\nSolana attacker wallet: FVNFzqAny8spWdPmYw6RQ9TkYa29ueFFiqCFD1gQnCEj\nEthereum address: 0x2cE21E4921d3Eb116526c3651Dac0257657338D5\nTornado Cash deposit: https://etherscan.io/address/0x2cE21E4921d3Eb116526c3651Dac0257657338D5\n\n**Source:** [https://twitter.com/CertiKAlert/status/2093428949334266091](https://twitter.com/CertiKAlert/status/2093428949334266091)",
+    "images": [],
+    "Lost": "$1.02M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-08-30.

Added **1** new incident(s): Avici

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Avici | Solana | Smart Contract Exploit | 1020000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
