### PR TITLE
feat: add Discord-sourced incidents 2026-09-02

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -18,6 +18,15 @@
     "chain": "Cronos"
   },
   {
+    "date": "20260831",
+    "name": "Aquifer",
+    "type": "CPI Exploit",
+    "Lost": 2500000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Solana"
+  },
+  {
     "date": "20260829",
     "name": "Avici",
     "type": "Smart Contract Exploit",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6635,5 +6635,13 @@
     "images": [],
     "Lost": "$28.0K",
     "Contract": ""
+  },
+  "Aquifer": {
+    "type": "CPI Exploit",
+    "date": "2026-08-31",
+    "rootCause": "Caller-controlled input-side token program was not pinned to canonical SPL Token Program. Aquifer trusted CPI results without verifying actual tokenIn balance delta, allowing attackers to receive real output tokens without providing required input. Attacker supplied malicious tokenProgram during swap that returned success without executing actual token transfer. Exploited via 90+ attack transactions.\n\n**Attack Tx:** [https://solscan.io/tx/2BANKvZf8qop1BcZuEH766h3JzfNFMndF8dzzWmk8uJ2ecgDDWCcH6PfaG3KgDWicC9qqNyCGUHZ5JMeh7z55Siy](https://solscan.io/tx/2BANKvZf8qop1BcZuEH766h3JzfNFMndF8dzzWmk8uJ2ecgDDWCcH6PfaG3KgDWicC9qqNyCGUHZ5JMeh7z55Siy)\n\n**Source:** [https://twitter.com/Phalcon_xyz/status/2094654751581610363](https://twitter.com/Phalcon_xyz/status/2094654751581610363)",
+    "images": [],
+    "Lost": "$2.50M",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-09-02.

Added **1** new incident(s): Aquifer

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Aquifer | Solana | CPI Exploit | 2500000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
