### PR TITLE
feat: add Discord-sourced incidents 2026-09-03

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -1,5 +1,14 @@
 [
   {
+    "date": "20260902",
+    "name": "Geb",
+    "type": "Access Control Bypass",
+    "Lost": 5.9436,
+    "lossType": "ETH",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260901",
     "name": "FloatProtocol",
     "type": "Flash Loan",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6643,5 +6643,13 @@
     "images": [],
     "Lost": "$2.50M",
     "Contract": ""
+  },
+  "Geb": {
+    "type": "Access Control Bypass",
+    "date": "2026-09-02",
+    "rootCause": "`GebProxyActions.quitSystem` lacks caller access control. Victims previously called it directly instead of via DSProxy delegatecall, causing `ownsSAFE[safe]` to be set to the GebProxyActions contract. Attacker called `GebProxyActions.quitSystem(manager, safe, dst)` directly, bypassing `GebSafeManager`'s `safeAllowed` check and transferring collateral to themselves. **Attacker:** `0xb929c7215c0ec8ebad5fbf73b1da63bccfff1896`\n\n**Attack Tx:** [https://etherscan.io/tx/0xfbce28e35c26358110dd9ed91f9ceef588acb264c3cf6c573df65ca21335058f](https://etherscan.io/tx/0xfbce28e35c26358110dd9ed91f9ceef588acb264c3cf6c573df65ca21335058f)\n\n**Source:** [https://twitter.com/SlowMist_Team/status/2094986310683705835](https://twitter.com/SlowMist_Team/status/2094986310683705835)",
+    "images": [],
+    "Lost": "5.94 ETH",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-09-03.

Added **1** new incident(s): Geb

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| Geb | Ethereum | Access Control Bypass | 5.9436 ETH |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
