### PR TITLE
feat: add Discord-sourced incidents 2026-09-08

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -18,6 +18,15 @@
     "chain": "Ethereum"
   },
   {
+    "date": "20260905",
+    "name": "SecuredFi",
+    "type": "Flash Loan",
+    "Lost": 104000.0,
+    "lossType": "USD",
+    "Contract": "",
+    "chain": "Ethereum"
+  },
+  {
     "date": "20260904",
     "name": "NotionalFinance",
     "type": "Integer Downcast",

--- a/rootcause_data.json
+++ b/rootcause_data.json
@@ -6683,5 +6683,13 @@
     "images": [],
     "Lost": "$287.0K",
     "Contract": ""
+  },
+  "SecuredFi": {
+    "type": "Flash Loan",
+    "date": "2026-09-05",
+    "rootCause": "Flash loan exploit of collateral valuation bug in OrderBookLib. Attacker self-trades to manipulate market price via getMarketUnitPrice() (blockTotalAmount / blockTotalFutureValue). Fake lend positions counted as collateral despite isReliableBlock guard being ineffective against flash loans. Coordinated attacks drained WBTC (~$72K) and USDC via multiple flash loan transactions.\n\n**Attack Tx:** [https://etherscan.io/tx/0x48417f7cdf6cabe29b7e99d4c8ebcbcf58fbc454a64a9044abc5c397120ad141](https://etherscan.io/tx/0x48417f7cdf6cabe29b7e99d4c8ebcbcf58fbc454a64a9044abc5c397120ad141)\n\n**Source:** [https://twitter.com/DefimonAlerts/status/2096855557575458950](https://twitter.com/DefimonAlerts/status/2096855557575458950)",
+    "images": [],
+    "Lost": "$104.0K",
+    "Contract": ""
   }
 }


### PR DESCRIPTION
## Summary
Incidents extracted from Discord **security-alert** channel for 2026-09-08.

Added **1** new incident(s): SecuredFi

## Incidents

| Name | Chain | Root Cause | Lost |
|------|-------|-----------|------|
| SecuredFi | Ethereum | Flash Loan | 104000 USD |

> Auto-generated by KeyFrame daily pipeline from Discord security-alert alerts.
> Root cause details and tx links are in `rootcause_data.json`.
